### PR TITLE
Log CMC messages, fixes #35

### DIFF
--- a/apps/server/lib/prodigy/server/protocol/dia/packet.ex
+++ b/apps/server/lib/prodigy/server/protocol/dia/packet.ex
@@ -145,8 +145,8 @@ defmodule Prodigy.Server.Protocol.Dia.Packet do
 
   @spec encode(Fm9.t()) :: binary()
   def encode(%Fm9{} = packet) do
-    <<6, 0::1, 9::7, packet.function.value, packet.reason.value, packet.flags.store_by_key::1,
-      packet.flags.retrieve_by_key::1, packet.flags.binary_data::1, packet.flags.ascii_data::1,
+    <<6, 0::1, 9::7, packet.function.value, packet.reason.value, bool2int(packet.flags.store_by_key)::1,
+      bool2int(packet.flags.retrieve_by_key)::1, bool2int(packet.flags.binary_data)::1, bool2int(packet.flags.ascii_data)::1,
       0::4, byte_size(packet.payload), packet.payload::binary>>
   end
 

--- a/apps/server/lib/prodigy/server/service/cmc.ex
+++ b/apps/server/lib/prodigy/server/service/cmc.ex
@@ -24,42 +24,65 @@ defmodule Prodigy.Server.Service.Cmc do
   alias Prodigy.Server.Session
   alias Prodigy.Server.Protocol.Dia.Packet.{Fm0, Fm9}
 
-  def handle(%Fm0{payload: %Fm9{payload: _payload}} = request, %Session{} = session) do
+  def handle(%Fm0{fm9: %Fm9{payload: payload}} = request, %Session{} = session) do
     Logger.debug("cmc got #{inspect(request, base: :hex, limit: :infinity)}")
 
-    # will have an FM9 header, not concatenated
-    # function code = 3 (alert)
-    # reason code = 2 (reception-oriented)
-    # flags = 0x90 (store by key, ascii)
-    # text length
+    # TODO insert the error details into the database
 
-    # architected text:
+    case payload do
+        <<
+          user_id::binary-size(7),          # right padded with '?'
+          "  ",
+          system_origin,                    # "T" = Trintex
+          msg_origin::binary-size(3),       # "PCM" = pcmessage
+          unit_id::binary-size(2),          # ascii decimals, "10" typical
+          error_code::binary-size(2),       # ascii decimals, "02" typical
+          severity_level,                   # 'E'
+          " ",
+          error_threshold::binary-size(3),  # "001"
+          " ",
+          date::binary-size(8),             # '05231988' typical
+          time::binary-size(6),             # '143023' typical
+          api_event::binary-size(5),        # '00003' typical
+          mem_to_start::binary-size(8),     # '00227472' typical
+          dos_version::binary-size(5),      # '03.30' typical
+          rs_version::binary-size(8),       # '6.01.XX' typical
+          window_id::binary-size(11),       # 'NOWINDOWIDX' typical
+          window_last::binary-size(2),      # in ascii hex, '0104' typical
+          selected_id::binary-size(11),     # 'NOSELECTORX' typical
+          selected_last::binary-size(2),    # '0104 typical
+          base_id::binary-size(11),         # 'PIOT0010MAP' typical
+          base_last::binary-size(2),        # '0104' typical
+          keyword::binary-size(13)          # 'QUOTE TRACK  ' typical
+        >> ->
+          msg = """
+          CMC FM9 Error reported by Reception System
 
-    #    <<
-    #      user_id::binary-size(7),          # right padded with '?'
-    #      "  ",
-    #      system_origin,                    # "T" = Trintex
-    #      msg_origin::binary-size(3),       # "PCM" = pcmessage
-    #      unit_id::binary-size(2),          # ascii decimals, "10" typical
-    #      error_code::binary-size(2),       # ascii decimals, "02" typical
-    #      severity_level,                   # 'E'
-    #      " ",
-    #      error_threshold::binary-size(3),  # "001"
-    #      " ",
-    #      date::binary-size(8),             # '05231988' typical
-    #      time::binary-size(6),             # '143023' typical
-    #      api_event::binary-size(5),        # '00003' typical
-    #      mem_to_start::binary-size(8),     # '00227472' typical
-    #      dos_version::binary-size(5),      # '03.30' typical
-    #      rs_version::binary-size(8),       # '6.01.XX' typical
-    #      window_id::binary-size(11),       # 'NOWINDOWIDX' typical
-    #      window_last::binary-size(2),      # in ascii hex, '0104' typical
-    #      selected_id::binary-size(11),     # 'NOSELECTORX' typical
-    #      selected_last::binary-size(4),    # '0104 typical
-    #      base_id::binary-size(11),         # 'PIOT0010MAP' typical
-    #      base_last::binary-size(2),        # '0104' typical
-    #      keyword::binary-size(13)          # 'QUOTE TRACK  ' typical
-    #    >>
+                  User ID: #{user_id}
+            System Origin: #{system_origin}
+           Message Origin: #{msg_origin}
+                  Unit ID: #{unit_id}
+               Error Code: #{error_code}
+           Severity Level: #{severity_level}
+          Error Threshold: #{error_threshold}
+                     Date: #{date}
+                     Time: #{time}
+                API Event: #{api_event}
+             Starting RAM: #{mem_to_start}
+              DOS Version: #{dos_version}
+               RS Version: #{rs_version}
+                Window ID: #{window_id}
+              Window Last: #{inspect window_last, base: :hex}
+              Selected ID: #{selected_id}
+            Selected Last: #{inspect selected_last, base: :hex}
+                  Base ID: #{base_id}
+                Base Last: #{inspect base_last, base: :hex}
+                  Keyword: #{keyword}
+          """
+          Logger.warn(msg)
+        _ ->
+          Logger.warn("CMC received message in unknown format: #{inspect payload, base: :hex, limit: :infinity}")
+      end
 
     {:ok, session, <<>>}
   end

--- a/apps/server/test/prodigy/server/service/cmc_test.exs
+++ b/apps/server/test/prodigy/server/service/cmc_test.exs
@@ -1,0 +1,99 @@
+# Copyright 2022, Phillip Heller
+#
+# This file is part of Prodigy Reloaded.
+#
+# Prodigy Reloaded is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# Prodigy Reloaded is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+# the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License along with Prodigy Reloaded. If not,
+# see <https://www.gnu.org/licenses/>.
+
+defmodule Prodigy.Server.Service.Cmc.Test do
+  @moduledoc false
+  use Prodigy.Server.RepoCase
+
+  import ExUnit.CaptureLog
+
+  require Logger
+
+  alias Prodigy.Server.Protocol.Dia.Packet.{Fm0, Fm9}
+  alias Prodigy.Server.Protocol.Dia.Packet.Fm9.{Flags, Function, Reason}
+  alias Prodigy.Server.Router
+
+#  @moduletag :capture_log
+
+  setup do
+    {:ok, router_pid} = GenServer.start_link(Router, nil)
+
+    [router_pid: router_pid]
+  end
+
+  test "error report", context do
+    fm0 = %Fm0{
+      concatenated: true,
+      src: 0x0,
+      dest: 0x020200,
+      logon_seq: 0,
+      message_id: 0,
+      function: Fm0.Function.APPL_0,
+      payload: <<>>,
+      mode: %Fm0.Mode{
+        compaction: false,
+        encryption: false,
+        logging_required: false,
+        reserved: false,
+        response: false,
+        response_expected: false,
+        timeout_message_required: false,
+        unsolicited_message: false
+      },
+      fm9: %Fm9{
+        concatenated: false,
+        function: Function.ALERT,
+        reason: Reason.RECEPTION_SYSTEM,
+        flags: %Flags{
+          store_by_key: true,
+          retrieve_by_key: false,
+          binary_data: false,
+          ascii_data: true
+        },
+        payload: <<
+          "AAAA12A",
+          "  ",
+          "T",
+          "PCM",
+          "10",
+          "02",
+          "E",
+          " ",
+          "001",
+          " ",
+          "05231988",
+          "143023",
+          "00003",
+          "00227472",
+          "03.30",
+          " 6.01.XX",
+          "NOWINDOWIDX",
+          0x01, 0x04,
+          "NOSELECTORX",
+          0x01, 0x04,
+          "PIOT0010MAP",
+          0x01, 0x04,
+          "QUOTE TRACK  "
+        >>
+      }
+    }
+
+    assert capture_log([level: :warn], fn ->
+           Router.handle_packet(context.router_pid, fm0)
+    end) =~ "CMC FM9"
+
+    # TODO assert the message was inserted into the database
+  end
+end

--- a/config/test.exs
+++ b/config/test.exs
@@ -25,4 +25,4 @@ config :core, Prodigy.Core.Data.Repo,
 config :server,
   auth_timeout: 3000
 
-config :logger, level: :error
+config :logger, level: :info


### PR DESCRIPTION
- emits warning level log with data sent to CMC, formatted if possible
- corresponding test
- sending CMC logs to the database is still TBD.
- increased test config log verbosity for CMC log capture test