### PR TITLE
Refactor Mailbox Schema

### DIFF
--- a/apps/core/lib/prodigy/core/data/message.ex
+++ b/apps/core/lib/prodigy/core/data/message.ex
@@ -25,12 +25,10 @@ defmodule Prodigy.Core.Data.Message do
 
   # TODO denormalize this
 
-  @primary_key false
   schema "message" do
     field(:from_id, :string)
     field(:from_name, :string)
-    field(:to_id, :string, primary_key: true)
-    field(:index, :integer, primary_key: true)
+    field(:to_id, :string)
     field(:subject, :string)
     field(:sent_date, :utc_datetime)
     field(:retain_date, :utc_datetime)

--- a/apps/core/priv/repo/migrations/20250907183440_fix_message_ids.exs
+++ b/apps/core/priv/repo/migrations/20250907183440_fix_message_ids.exs
@@ -17,7 +17,6 @@ defmodule Prodigy.Core.Data.Repo.Migrations.FixMessageIds do
     alter table(:message) do
       remove :id
       add :index, :integer
-      add :to_id_primary, :boolean  # We'll need to handle the composite key separately
     end
 
     # Recreate the composite primary key

--- a/apps/core/priv/repo/migrations/20250907183440_fix_message_ids.exs
+++ b/apps/core/priv/repo/migrations/20250907183440_fix_message_ids.exs
@@ -1,0 +1,26 @@
+defmodule Prodigy.Core.Data.Repo.Migrations.FixMessageIds do
+  use Ecto.Migration
+
+  def up do
+    # Drop the existing composite primary key constraint
+    drop constraint(:message, "message_pkey")
+
+    # Remove the old primary key columns and add new id
+    alter table(:message) do
+      remove :index
+      add :id, :bigserial, primary_key: true
+    end
+  end
+
+  def down do
+    # Reverse the changes
+    alter table(:message) do
+      remove :id
+      add :index, :integer
+      add :to_id_primary, :boolean  # We'll need to handle the composite key separately
+    end
+
+    # Recreate the composite primary key
+    create constraint(:message, "message_pkey", primary_key: [:to_id, :index])
+  end
+end

--- a/apps/server/lib/prodigy/server/service/messaging.ex
+++ b/apps/server/lib/prodigy/server/service/messaging.ex
@@ -64,26 +64,17 @@ defmodule Prodigy.Server.Service.Messaging do
     expunge_date = Timex.shift(send_date, days: 14)
 
     Enum.each(to_ids, fn to_id ->
-      Repo.transaction(fn ->
-        max_index =
-          Message
-          |> Ecto.Query.where([m], m.to_id == ^to_id)
-          |> Ecto.Query.select([m], count(m.index))
-          |> Repo.one()
-
-        Repo.insert!(%Message{
-          from_id: from_id,
-          from_name: from_name |> String.slice(0..17),
-          to_id: to_id,
-          index: max_index + 1,
-          subject: subject |> String.slice(0..19),
-          sent_date: send_date,
-          retain_date: expunge_date,
-          contents: body,
-          retain: false,
-          read: false
-        })
-      end)
+      Repo.insert!(%Message{
+        from_id: from_id,
+        from_name: from_name |> String.slice(0..17),
+        to_id: to_id,
+        subject: subject |> String.slice(0..19),
+        sent_date: send_date,
+        retain_date: expunge_date,
+        contents: body,
+        retain: false,
+        read: false
+      })
     end)
   end
 
@@ -111,50 +102,88 @@ defmodule Prodigy.Server.Service.Messaging do
     :ok
   end
 
-  defp get_message(index, to_id) do
-    {:ok, message} =
-      Repo.transaction(fn ->
-        message =
-          Message
-          |> Ecto.Query.where([m], m.to_id == ^to_id)
-          |> Ecto.Query.where([m], m.index == ^index)
-          |> Repo.one()
-
-        changeset = Message.changeset(message, %{read: true})
-        Repo.update(changeset)
-
-        message
-      end)
-
-    length = byte_size(message.contents)
-
-    res = <<
-      0::104,
-      length::16-big,
-      message.contents::binary
-    >>
-
-    {:ok, res}
+  defp load_message_ids(user_id) do
+    Message
+    |> Ecto.Query.where([m], m.to_id == ^user_id)
+    |> Ecto.Query.order_by([m], [desc: m.sent_date, desc: m.id ])
+    |> Ecto.Query.select([m], m.id)
+    |> Ecto.Query.limit(252)
+    |> Repo.all()
   end
 
-  defp get_mailbox_page(page, user_id) do
-    total_messages =
-      Message
-      |> Ecto.Query.where([m], m.to_id == ^user_id)
-      |> Ecto.Query.select([m], count(m.index))
-      |> Repo.one()
+  defp get_message(client_index, session) do
+    # Client index is 1-based, Elixir lists are 0-based
+    message_id = Enum.at(session.messaging.message_ids, client_index)
 
-    messages =
-      Message
-      |> Ecto.Query.where([m], m.to_id == ^user_id)
-      |> Ecto.Query.order_by([m], desc: m.sent_date)
-      |> Ecto.Query.from(limit: 4, offset: (^page - 1) * 4)
-      |> Repo.all()
+    if message_id do
+      {:ok, message} =
+        Repo.transaction(fn ->
+          # Verify the message belongs to the current user
+          message =
+            Message
+            |> Ecto.Query.where([m], m.id == ^message_id)
+            |> Ecto.Query.where([m], m.to_id == ^session.user.id)
+            |> Repo.one()
+
+          if message do
+            changeset = Message.changeset(message, %{read: true})
+            {:ok, updated} = Repo.update(changeset)
+            updated
+          else
+            nil
+          end
+        end)
+
+      if message do
+        length = byte_size(message.contents)
+
+        res = <<
+          0::104,
+          length::16-big,
+          message.contents::binary
+        >>
+
+        {:ok, res}
+      else
+        Logger.error("Message #{message_id} not found or unauthorized for user #{session.user.id}")
+        {:error, "Message not found"}
+      end
+    else
+      Logger.error("Invalid message index: #{client_index}")
+      {:error, "Message not found"}
+    end
+  end
+
+  defp get_mailbox_page(page, session) do
+    message_ids = session.messaging.message_ids
+    total_messages = length(message_ids)
+
+    # Calculate which message IDs are on this page (4 messages per page)
+    offset = (page - 1) * 4
+    page_message_ids = Enum.slice(message_ids, offset, 4)
+
+    messages = if length(page_message_ids) > 0 do
+      # Fetch messages without ordering
+      messages_map =
+        Message
+        |> Ecto.Query.where([m], m.id in ^page_message_ids)
+        |> Repo.all()
+        |> Map.new(&{&1.id, &1})
+
+      # Return them in the exact order from page_message_ids
+      page_message_ids
+      |> Enum.map(&Map.get(messages_map, &1))
+      |> Enum.filter(&(&1 != nil))
+    else
+      []
+    end
 
     messages_on_page = length(messages)
 
     message_payload =
-      Enum.reduce(messages, <<>>, fn message, buf ->
+      messages
+      |> Enum.with_index(offset)  # Calculate client index starting from offset
+      |> Enum.reduce(<<>>, fn {message, client_index}, buf ->
         sent_date = Timex.format!(message.sent_date, "{0M}/{0D}")
         retain_date = Timex.format!(message.retain_date, "{0M}/{0D}")
         retain = bool2int(message.retain)
@@ -163,28 +192,28 @@ defmodule Prodigy.Server.Service.Messaging do
         subject_length = String.length(message.subject)
 
         buf <>
-          <<
-            message.index::16-big,
-            message.from_id::binary-size(7),
-            # 1 = last message?  (when true, loads MSZC0000.MAP which maybe lacks "next mail") ?
-            0::1,
-            # 1 = retained, 0 = not retained
-            retain::1,
-            # ?
-            0::1,
-            # 1 = read, 0 = unread (show "*")
-            read::1,
-            # ?
-            0x0::4,
-            # 2nd flag byte - one of these indicates another field follows the subject, I think
-            0,
-            sent_date::binary-size(5),
-            retain_date::binary-size(5),
-            from_name_length,
-            message.from_name::binary-size(from_name_length),
-            subject_length,
-            message.subject::binary-size(subject_length)
-          >>
+        <<
+          client_index::16-big,  # Use calculated client index
+          message.from_id::binary-size(7),
+          # 1 = last message?  (when true, loads MSZC0000.MAP which maybe lacks "next mail") ?
+          0::1,
+          # 1 = retained, 0 = not retained
+          retain::1,
+          # ?
+          0::1,
+          # 1 = read, 0 = unread (show "*")
+          read::1,
+          # ?
+          0x0::4,
+          # 2nd flag byte - one of these indicates another field follows the subject, I think
+          0,
+          sent_date::binary-size(5),
+          retain_date::binary-size(5),
+          from_name_length,
+          message.from_name::binary-size(from_name_length),
+          subject_length,
+          message.subject::binary-size(subject_length)
+        >>
       end)
 
     {:ok, <<total_messages::16-big, messages_on_page, message_payload::binary>>}
@@ -195,43 +224,57 @@ defmodule Prodigy.Server.Service.Messaging do
       Message
       |> Ecto.Query.where([m], m.to_id == ^user.id)
       |> Ecto.Query.where([m], m.read == false)
-      |> Ecto.Query.select([m], count(m.index))
+      |> Ecto.Query.select([m], count(m.id))
       |> Repo.one()
 
     unread_message_count > 0
   end
 
-  defp do_disposition(<< 0x4, count::16-big, rest::binary >>, user) do
+  defp do_disposition(<< 0x4, count::16-big, rest::binary >>, session) do
     byte_count = count * 2
     << data::binary-size(byte_count), rest::binary >> = rest
 
-    indices = for << index::16-big <- data >>, do: index
+    client_indices = for << index::16-big <- data >>, do: index
 
-    Logger.debug("delete message indices: #{inspect indices}")
+    # Map client indices to message IDs
+    message_ids_to_delete = client_indices
+    |> Enum.map(fn idx -> Enum.at(session.messaging.message_ids, idx) end)
+    |> Enum.filter(&(&1 != nil))
+
+    Logger.debug("delete message indices: #{inspect message_ids_to_delete}")
 
     {:ok, message} =
       Repo.transaction(fn ->
         Message
-        |> Ecto.Query.where([m], m.to_id == ^user.id)
-        |> Ecto.Query.where([m], m.index in ^indices)
+        |> Ecto.Query.where([m], m.to_id == ^session.user.id)
+        |> Ecto.Query.where([m], m.id in ^message_ids_to_delete)
         |> Repo.delete_all()
       end)
 
-    do_disposition(rest, user)
+    # explicitly don't mutate the session message_ids because we might have more references that
+    # are to it as is.  Also, we only call dispose when we are leaving messaging.  Guarantee to
+    # have a get_message_page(1) call if client comes back, which will refresh session
+
+    do_disposition(rest, session)
   end
 
-  defp do_disposition(<< 0x5, count::16-big, rest::binary >>, user) do
+  defp do_disposition(<< 0x5, count::16-big, rest::binary >>, session) do
     byte_count = count * 2
     << data::binary-size(byte_count), rest::binary >> = rest
 
-    indices = for << index::16-big <- data >>, do: index
+    client_indices = for << index::16-big <- data >>, do: index
 
-    Logger.debug("retain message indices: #{inspect indices}")
+    # Map client indices to message IDs
+    message_ids_to_retain = client_indices
+    |> Enum.map(fn idx -> Enum.at(session.messaging.message_ids, idx) end)
+    |> Enum.filter(&(&1 != nil))
+
+    Logger.debug("retain message indices: #{inspect message_ids_to_retain}")
 
     Repo.transaction(fn ->
       messages = Message
-      |> Ecto.Query.where([m], m.to_id == ^user.id)
-      |> Ecto.Query.where([m], m.index in ^indices)
+      |> Ecto.Query.where([m], m.to_id == ^session.user.id)
+      |> Ecto.Query.where([m], m.id in ^message_ids_to_retain)
       |> Ecto.Query.where([m], m.retain == false)
       |> Repo.all()
 
@@ -244,18 +287,19 @@ defmodule Prodigy.Server.Service.Messaging do
       end)
     end)
 
-    do_disposition(rest, user)
+    do_disposition(rest, session)
   end
 
-  defp do_disposition(<< 0xff >>, user) do
+  defp do_disposition(<< 0xff >>, session) do
     # done
     Logger.debug("done processing dispositions")
+    session
   end
 
   def handle(%Fm0{payload: <<0x1, payload::binary>>} = request, %Session{} = session) do
     Logger.debug("messaging got payload: #{inspect(payload, base: :hex, limit: :infinity)}")
 
-    response =
+    {session, response} =
       case payload do
         # this is sent when jumping to "communication"; this response causes
         # option 2 to read "offline communications", which loads MP000000.PGM (missing)
@@ -263,21 +307,34 @@ defmodule Prodigy.Server.Service.Messaging do
 
         # this response loads the page as normal, option 2 is "mailbox"
         <<0x1E, _rest::binary>> ->
-          {:ok, <<0>>}
+          {session, {:ok, <<0>>}}
 
+        # Mailbox page request - check if we need to load message IDs
         <<0xA, page, _rest::binary>> ->
-          get_mailbox_page(page, session.user.id)
+          session = if page == 1 or not Map.has_key?(session, :messaging) or is_nil(session.messaging) do
+            message_ids = load_message_ids(session.user.id)
+            Map.put(session, :messaging, %{message_ids: message_ids})
+          else
+            session
+          end
+
+          {session, get_mailbox_page(page, session)}
 
         <<0x3, 0x3, index::16-big, 0x1, 0xF4>> ->
-          get_message(index, session.user.id)
+          {session, get_message(index, session)}
 
         <<0x1, 0x2, payload::binary>> ->
-          internal_send_message(session.user, payload)
+          {session, internal_send_message(session.user, payload)}
+
+          # Request for next message within full message view
+        <<0x3, index::16-big>> ->
+          {session, get_message(index, session)}
 
         <<0x4, rest::binary>> ->
-          do_disposition(payload, session.user) # deletes
+          {do_disposition(payload, session), :ok} # deletes
+
         <<0x5, rest::binary>> ->
-          do_disposition(payload, session.user) # retains
+          {do_disposition(payload, session), :ok} # retains
 
         _ ->
           Logger.warn(

--- a/apps/server/lib/prodigy/server/session.ex
+++ b/apps/server/lib/prodigy/server/session.ex
@@ -21,7 +21,7 @@ defmodule Prodigy.Server.Session do
   persists until the connection is terminated.
   """
 
-  defstruct [:user, :rs_version, :auth_timeout]
+  defstruct [:user, :rs_version, :auth_timeout, :messaging]
 
   def set_auth_timer do
     Process.send_after(self(), :auth_timeout, Application.fetch_env!(:server, :auth_timeout))

--- a/apps/server/test/prodigy/server/service/messaging_test.exs
+++ b/apps/server/test/prodigy/server/service/messaging_test.exs
@@ -350,13 +350,13 @@ defmodule Prodigy.Server.Service.Messaging.Test do
     message_payload = <<
       0x04,       # delete
       2::16-big,  # delete 2 messages
-      0::16-big,  # client index 1 (Test 6)
-      2::16-big,  # client index 3 (Test 4)
+      0::16-big,  # client index 0 (Test 6)
+      2::16-big,  # client index 2 (Test 4)
       0x05,       # retain
       3::16-big,  # retain 3 messages
-      1::16-big,  # client index 2 (Test 5)
-      3::16-big,  # client index 4 (Test 3)
-      5::16-big,  # client index 6 (Test 1)
+      1::16-big,  # client index 1 (Test 5)
+      3::16-big,  # client index 3 (Test 3)
+      5::16-big,  # client index 5 (Test 1)
       0xFF        # done
     >>
 

--- a/apps/server/test/prodigy/server/service/messaging_test.exs
+++ b/apps/server/test/prodigy/server/service/messaging_test.exs
@@ -144,27 +144,36 @@ defmodule Prodigy.Server.Service.Messaging.Test do
     {0, 0, _rest} = get_mailbox_page(context, 1)
 
     Messaging.send_message("ZZZZ00A", "Test User", ["AAAA12A"], [], "Test 1", "Test 1")
+
+    # Client must reload page 1 to see new messages (simulating leaving and re-entering mailbox)
     {1, 1, _rest} = get_mailbox_page(context, 1)
 
     Messaging.send_message("ZZZZ00A", "Test User", ["AAAA12A"], [], "Test 2", "Test 2")
     Messaging.send_message("ZZZZ00A", "Test User", ["AAAA12A"], [], "Test 3", "Test 3")
     Messaging.send_message("ZZZZ00A", "Test User", ["AAAA12A"], [], "Test 4", "Test 4")
+
+    # Client reloads mailbox
     {4, 4, _rest} = get_mailbox_page(context, 1)
 
     Messaging.send_message("ZZZZ00A", "Test User", ["AAAA12A"], [], "Test 5", "Test 5")
+
+    # Client reloads mailbox again
     {5, 4, _rest} = get_mailbox_page(context, 1)
 
     Messaging.send_message("ZZZZ00A", "Test User", ["AAAA12A"], [], "Test 6", "Test 6")
+
+    # Client reloads mailbox and then navigates to page 2
+    {6, 4, _rest} = get_mailbox_page(context, 1)
     {6, 2, rest} = get_mailbox_page(context, 2)
 
     # make sure the messages on page 2 are as expected
+    # Messages should be Test 2 and Test 1 (oldest) since we show newest first
+    # and page 1 has Test 6, 5, 4, 3
 
-    # Timex mock above not working as expected; will ignore values for now
-    # sent_date = Timex.format!(epoch(), "{0M}/{0D}")
-    # u retain_date = Timex.format!(Timex.shift(epoch(), days: 14), "{0M}/{0D}")
-    <<5::16-big, "ZZZZ00A", 0, 0, sent_date::binary-size(5), retain_date::binary-size(5), 9,
-      "Test User", 6, "Test 5", 6::16-big, "ZZZZ00A", 0, 0, sent_date::binary-size(5),
-      retain_date::binary-size(5), 9, "Test User", 6, "Test 6">> = rest
+    # The client indices for page 2 should be 4 and 5
+    <<4::16-big, "ZZZZ00A", 0, 0, sent_date::binary-size(5), retain_date::binary-size(5), 9,
+      "Test User", 6, "Test 2", 5::16-big, "ZZZZ00A", 0, 0, sent_date::binary-size(5),
+      retain_date::binary-size(5), 9, "Test User", 6, "Test 1">> = rest
 
     logoff(context.router_pid)
   end
@@ -177,20 +186,20 @@ defmodule Prodigy.Server.Service.Messaging.Test do
     Messaging.send_message("ZZZZ00A", "Test User", ["AAAA12A"], [], "Test 1", "Test 1")
 
     {1, 1,
-     <<index::16-big, "ZZZZ00A", 0::16, _dates::binary-size(10), 9, "Test User", 6, "Test 1">>} =
+      <<index::16-big, "ZZZZ00A", 0::16, _dates::binary-size(10), 9, "Test User", 6, "Test 1">>} =
       get_mailbox_page(context, 1)
 
     # check a second time to be sure the read flag isn't set
     {1, 1,
-     <<^index::16-big, "ZZZZ00A", 0::16, _dates::binary-size(10), 9, "Test User", 6, "Test 1">>} =
+      <<^index::16-big, "ZZZZ00A", 0::16, _dates::binary-size(10), 9, "Test User", 6, "Test 1">>} =
       get_mailbox_page(context, 1)
 
     "Test 1" = get_message(context, index)
 
     # check a third time and the read flag should be set
     {1, 1,
-     <<^index::16-big, "ZZZZ00A", 0::3, 1::1, 0::12, _dates::binary-size(10), 9, "Test User", 6,
-       "Test 1">>} = get_mailbox_page(context, 1)
+      <<^index::16-big, "ZZZZ00A", 0::3, 1::1, 0::12, _dates::binary-size(10), 9, "Test User", 6,
+        "Test 1">>} = get_mailbox_page(context, 1)
 
     logoff(context.router_pid)
   end
@@ -215,11 +224,25 @@ defmodule Prodigy.Server.Service.Messaging.Test do
 
     assert 6 ==  Message |> Repo.aggregate(:count)
 
+    # Client enters mailbox - this loads the message IDs into session
+    {6, 4, _rest} = get_mailbox_page(context, 1)
+
+    # Get the actual message IDs that will be deleted (client indices 0 and 2)
+    # Since messages are ordered newest first: Test 6, 5, 4, 3, 2, 1
+    # Client index 0 = Test 6, Client index 2 = Test 4
+    messages_before = Message
+                      |> Ecto.Query.where([m], m.to_id == "AAAA12A")
+                      |> Ecto.Query.order_by([m], [desc: m.sent_date, desc: m.id ])
+                      |> Repo.all()
+
+    # Get IDs of messages that should be deleted (1st and 3rd in the list)
+    deleted_ids = [Enum.at(messages_before, 0).id, Enum.at(messages_before, 2).id]
+
     message_payload = <<
       0x04,       # delete
       2::16-big,  # delete 2 messages
-      1::16-big,
-      3::16-big,
+      0::16-big,  # client index 0 (newest message - Test 6)
+      2::16-big,  # client index 2 (Test 4)
       0xFF        # done
     >>
 
@@ -233,7 +256,18 @@ defmodule Prodigy.Server.Service.Messaging.Test do
     })
 
     assert 4 == Message |> Repo.aggregate(:count)
-    assert 0 == Message |> Ecto.Query.where([m], m.index in [1, 3]) |> Repo.aggregate(:count)
+
+    # Verify the correct messages were deleted
+    assert 0 == Message |> Ecto.Query.where([m], m.id in ^deleted_ids) |> Repo.aggregate(:count)
+
+    # Verify Test 5, 3, 2, 1 remain
+    remaining = Message
+                |> Ecto.Query.where([m], m.to_id == "AAAA12A")
+                |> Ecto.Query.order_by([m], [desc: m.sent_date, desc: m.id ])
+                |> Repo.all()
+
+    assert 4 == length(remaining)
+    assert ["Test 5", "Test 3", "Test 2", "Test 1"] == Enum.map(remaining, & &1.subject)
 
     logoff(context.router_pid)
   end
@@ -252,12 +286,15 @@ defmodule Prodigy.Server.Service.Messaging.Test do
 
     assert 6 == Message |> Ecto.Query.where([m], m.retain == false) |> Repo.aggregate(:count)
 
+    # Client enters mailbox - this loads the message IDs into session
+    {6, 4, _rest} = get_mailbox_page(context, 1)
+
     message_payload = <<
       0x05,       # retain
       3::16-big,  # retain 3 messages
-      2::16-big,
-      4::16-big,
-      6::16-big,
+      1::16-big,  # client index 1 (Test 5)
+      3::16-big,  # client index 3 (Test 3)
+      5::16-big,  # client index 5 (Test 1)
       0xFF        # done
     >>
 
@@ -272,6 +309,15 @@ defmodule Prodigy.Server.Service.Messaging.Test do
 
     assert 6 == Message |> Repo.aggregate(:count)
     assert 3 == Message |> Ecto.Query.where([m], m.retain == true) |> Repo.aggregate(:count)
+
+    # Verify the correct messages were retained
+    retained = Message
+               |> Ecto.Query.where([m], m.to_id == "AAAA12A")
+               |> Ecto.Query.where([m], m.retain == true)
+               |> Ecto.Query.order_by([m], [desc: m.sent_date, desc: m.id ])
+               |> Repo.all()
+
+    assert ["Test 5", "Test 3", "Test 1"] == Enum.map(retained, & &1.subject)
 
     logoff(context.router_pid)
   end
@@ -290,16 +336,27 @@ defmodule Prodigy.Server.Service.Messaging.Test do
 
     assert 6 == Message |> Ecto.Query.where([m], m.retain == false) |> Repo.aggregate(:count)
 
+    # Client enters mailbox - this loads the message IDs into session
+    {6, 4, _rest} = get_mailbox_page(context, 1)
+
+    # Get the actual message IDs that will be deleted (client indices 0 and 2)
+    messages_before = Message
+                      |> Ecto.Query.where([m], m.to_id == "AAAA12A")
+                      |> Ecto.Query.order_by([m], [desc: m.sent_date, desc: m.id ])
+                      |> Repo.all()
+
+    deleted_ids = [Enum.at(messages_before, 0).id, Enum.at(messages_before, 2).id]
+
     message_payload = <<
       0x04,       # delete
       2::16-big,  # delete 2 messages
-      1::16-big,
-      3::16-big,
+      0::16-big,  # client index 1 (Test 6)
+      2::16-big,  # client index 3 (Test 4)
       0x05,       # retain
       3::16-big,  # retain 3 messages
-      2::16-big,
-      4::16-big,
-      6::16-big,
+      1::16-big,  # client index 2 (Test 5)
+      3::16-big,  # client index 4 (Test 3)
+      5::16-big,  # client index 6 (Test 1)
       0xFF        # done
     >>
 
@@ -313,8 +370,17 @@ defmodule Prodigy.Server.Service.Messaging.Test do
     })
 
     assert 4 == Message |> Repo.aggregate(:count)
-    assert 0 == Message |> Ecto.Query.where([m], m.index in [1, 3]) |> Repo.aggregate(:count)
+    assert 0 == Message |> Ecto.Query.where([m], m.id in ^deleted_ids) |> Repo.aggregate(:count)
     assert 3 == Message |> Ecto.Query.where([m], m.retain == true) |> Repo.aggregate(:count)
+
+    # Verify correct messages remain and are retained
+    retained = Message
+               |> Ecto.Query.where([m], m.to_id == "AAAA12A")
+               |> Ecto.Query.where([m], m.retain == true)
+               |> Ecto.Query.order_by([m], [desc: m.sent_date, desc: m.id ])
+               |> Repo.all()
+
+    assert ["Test 5", "Test 3", "Test 1"] == Enum.map(retained, & &1.subject)
 
     logoff(context.router_pid)
   end


### PR DESCRIPTION
- cache list of message ids in session on client entry to mailbox (when mailbox page 1 is retrieved)
- client message indexes are offsets into this cached list
- if client leaves and comes back to mailbox, client requests page 1 again, refreshing the cache