### PR TITLE
CI: build server + dowjones-sidecar images to GHCR

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,0 +1,65 @@
+name: Build images
+
+# On merge to main (and on demand), build the app container images and push them
+# to GHCR tagged by git SHA (immutable) plus a moving `main` tag. Deployers run a
+# specific SHA tag; staging tracks `main`. See prodigy-deploy for the deploy side.
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  OWNER: prodigyreloaded
+
+jobs:
+  build:
+    name: Build and push ${{ matrix.image }}
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: prodigy-server
+            context: .
+            file: apps/server/Dockerfile
+          - image: prodigy-dowjones-sidecar
+            context: dowjones_sidecar
+            file: dowjones_sidecar/Dockerfile
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Derive tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.image }}
+          tags: |
+            type=sha
+            type=raw,value=main,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.file }}
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/docker-compose.images.yaml
+++ b/docker-compose.images.yaml
@@ -1,0 +1,31 @@
+# Image overlay - run the app from prebuilt GHCR images instead of building on
+# the box. For DEPLOYERS (staging/production), not for local dev (dev keeps the
+# build-from-source override).
+#
+# Compose it AFTER the prod overlay and set IMAGE_TAG to the git SHA tag to run
+# (e.g. sha-abc1234); it defaults to `main` (the latest main build):
+#
+#   IMAGE_TAG=sha-abc1234 \
+#     docker compose -f docker-compose.yaml -f docker-compose.prod.yaml \
+#                    -f docker-compose.images.yaml pull
+#   IMAGE_TAG=sha-abc1234 \
+#     docker compose -f docker-compose.yaml -f docker-compose.prod.yaml \
+#                    -f docker-compose.images.yaml up -d --no-build
+#
+# `build: !reset null` drops the base build stanza so the service is pull-only.
+services:
+  server:
+    build: !reset null
+    image: ghcr.io/prodigyreloaded/prodigy-server:${IMAGE_TAG:-main}
+
+  db-migrate:
+    build: !reset null
+    image: ghcr.io/prodigyreloaded/prodigy-server:${IMAGE_TAG:-main}
+
+  db-seed:
+    build: !reset null
+    image: ghcr.io/prodigyreloaded/prodigy-server:${IMAGE_TAG:-main}
+
+  dowjones-sidecar:
+    build: !reset null
+    image: ghcr.io/prodigyreloaded/prodigy-dowjones-sidecar:${IMAGE_TAG:-main}


### PR DESCRIPTION
## What
Adds CI that builds the app container images and pushes them to GHCR, plus a compose overlay to run the stack from those images instead of building on the box. First step of the deploy-by-tag pipeline for staging/production.

## Changes
- **`.github/workflows/build-images.yml`** — on push to `main` (+ manual dispatch), builds and pushes, tagged `sha-<short>` (immutable) and `main` (moving), `linux/amd64`, with GHA layer cache:
  - `ghcr.io/prodigyreloaded/prodigy-server` (`apps/server/Dockerfile`)
  - `ghcr.io/prodigyreloaded/prodigy-dowjones-sidecar` (`dowjones_sidecar/Dockerfile`)
- **`docker-compose.images.yaml`** — a deploy overlay that swaps the `build:` stanzas for `image: ghcr.io/prodigyreloaded/…:${IMAGE_TAG:-main}` (server / db-migrate / db-seed / dowjones-sidecar), so deployers run prebuilt images.

## Not affected
- **Local dev** — `docker compose up` still builds from source via the dev override.
- **Current prod bring-up** — unchanged unless the new `-f docker-compose.images.yaml` overlay is composed in.

## Follow-up
- The deploy step (pull a tag + `up -d` on staging/prod) lands separately in the deploy repo.