### PR TITLE
Portal: show the built git revision in the footer; bump copyright to 2026

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -127,5 +127,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          # Bake the built commit into the image (portal footer shows it).
+          build-args: |
+            GIT_SHA=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/apps/portal/lib/portal/components/layouts.ex
+++ b/apps/portal/lib/portal/components/layouts.ex
@@ -17,4 +17,13 @@ defmodule Prodigy.Portal.Layouts do
   use Prodigy.Portal, :html
 
   embed_templates "layouts/*"
+
+  @doc """
+  Short git revision this build came from, shown in the footer. Baked into the
+  image via the GIT_SHA build arg (apps/server/Dockerfile); "dev" for source
+  builds.
+  """
+  def revision do
+    System.get_env("GIT_SHA", "dev") |> String.slice(0, 7)
+  end
 end

--- a/apps/portal/lib/portal/components/layouts/root.html.heex
+++ b/apps/portal/lib/portal/components/layouts/root.html.heex
@@ -371,7 +371,7 @@
       </div>
 
       <p class="small text-muted mt-2 mb-4">
-        Copyright &copy; 2025 by Phillip Heller &bull; All Rights Reserved &bull; Prodigy Reloaded is not affiliated with Prodigy Services Company, Sears, IBM, or CBS.
+        Copyright &copy; 2026 by Phillip Heller &bull; All Rights Reserved &bull; Prodigy Reloaded is not affiliated with Prodigy Services Company, Sears, IBM, or CBS. &bull; rev {revision()}
       </p>
     </footer>
   </div>

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -33,6 +33,11 @@ RUN cd apps/podbutil && mix escript.build
 
 FROM elixir:1.17.3-otp-27-slim AS run_stage
 
+# Git revision this image was built from; CI passes the commit sha, source
+# builds default to "dev". Surfaced in the portal footer.
+ARG GIT_SHA=dev
+ENV GIT_SHA=$GIT_SHA
+
 # Install git for cloning the objects repository
 RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
CI passes GIT_SHA into the server image build; the root layout footer renders the short revision so any environment shows exactly what it's running. Source builds show 'rev dev'.