### PR TITLE
Portal: enforce the invitation gate on the email/magic-link signup path

### DIFF
--- a/apps/portal/lib/portal/accounts.ex
+++ b/apps/portal/lib/portal/accounts.ex
@@ -24,7 +24,9 @@ defmodule Prodigy.Portal.Accounts do
   import Ecto.Query, warn: false
   alias Prodigy.Core.Data.Repo
 
-  alias Prodigy.Core.Data.Portal.{User, UserToken, Identity}
+  alias Prodigy.Core.Data.Portal.{User, UserToken, Identity, Invite}
+  alias Prodigy.Portal.Invites
+  alias Prodigy.Portal.Settings
   alias Prodigy.Portal.Accounts.Blacklist
   alias Prodigy.Portal.Accounts.RateLimit
   alias Prodigy.Portal.Accounts.UserNotifier
@@ -288,17 +290,20 @@ defmodule Prodigy.Portal.Accounts do
 
     case result do
       {:ok, user} -> {:logged_in, user}
+      # Invite lost the redeem race (shared single-use code / concurrent
+      # winner): the whole registration rolled back. Distinct from :blocked
+      # so the caller can offer a fresh code + re-auth.
+      {:error, :not_redeemable} -> :invite_taken
       _ -> :blocked
     end
   end
 
   defp maybe_redeem_invite(nil, _user), do: :ok
 
-  defp maybe_redeem_invite(invite, %User{} = redeemer) do
-    case invite |> Prodigy.Portal.Invites.redeem_changeset(redeemer) |> Repo.update() do
-      {:ok, _} -> :ok
-      {:error, _} = err -> err
-    end
+  # Atomic compare-and-set inside the caller's transaction; a loser
+  # (`:not_redeemable`) fails the `with` and rolls back the whole sign-up.
+  defp maybe_redeem_invite(%Invite{} = invite, %User{} = redeemer) do
+    Invites.redeem(invite, redeemer)
   end
 
   ## Settings
@@ -471,7 +476,7 @@ defmodule Prodigy.Portal.Accounts do
     * `:confirm` - arity-1, confirm-signup URL for a new email
     * `:dismiss` - arity-1, dismiss URL for the same token
   """
-  def request_access(email, url_fns)
+  def request_access(email, url_fns, opts \\ [])
       when is_binary(email) and is_list(url_fns) do
     email = email |> String.trim() |> String.downcase()
 
@@ -479,13 +484,14 @@ defmodule Prodigy.Portal.Accounts do
       not valid_email_format?(email) -> :ok
       Blacklist.blacklisted?(email) -> :ok
       RateLimit.check_invitation(email) == :blocked -> :ok
-      true -> dispatch_access_request(email, url_fns)
+      true -> dispatch_access_request(email, url_fns, Keyword.get(opts, :invite_code))
     end
   end
 
-  def request_access(_email, _url_fns), do: :ok
-
-  defp dispatch_access_request(email, url_fns) do
+  # Existing user: send a login link, no invite needed (mirrors the OAuth
+  # "existing identity: gate doesn't apply" rule). Brand-new email: the
+  # invitation gate applies, exactly as it does for OAuth signup.
+  defp dispatch_access_request(email, url_fns, invite_code) do
     case get_user_by_email(email) do
       %User{} = user ->
         case RateLimit.check_login(email) do
@@ -493,15 +499,34 @@ defmodule Prodigy.Portal.Accounts do
           :ok -> deliver_login_instructions(user, Keyword.fetch!(url_fns, :login))
         end
 
-      nil ->
-        deliver_signup_invitation(email, url_fns)
-    end
+        :ok
 
-    :ok
+      nil ->
+        if Settings.invitation_only?() do
+          case load_pending_invite(invite_code) do
+            {:ok, invite} ->
+              deliver_signup_invitation(email, url_fns, invite)
+              :ok
+
+            :missing ->
+              # No portal user was created and no email sent. Caller surfaces
+              # the invite-required prompt (backstop for a UI-bypassed submit).
+              {:error, :invite_required}
+          end
+        else
+          deliver_signup_invitation(email, url_fns, nil)
+          :ok
+        end
+    end
   end
 
-  defp deliver_signup_invitation(email, url_fns) do
-    {encoded, token} = UserToken.build_signup_invitation_token(email)
+  # Carry the redeemable invite's CODE (not a redemption) in the token so the
+  # actual single-use redeem happens atomically at click time, inside the
+  # user-creation transaction - never at send time, so a lost email can't burn
+  # the code.
+  defp deliver_signup_invitation(email, url_fns, invite) do
+    data = if invite, do: %{"invite_code" => invite.code}, else: nil
+    {encoded, token} = UserToken.build_signup_invitation_token(email, data)
     Repo.insert!(token)
 
     UserNotifier.deliver_signup_invitation(
@@ -521,23 +546,56 @@ defmodule Prodigy.Portal.Accounts do
   def consume_signup_invitation(encoded_token) when is_binary(encoded_token) do
     with {:ok, query} <- UserToken.verify_invitation_token(encoded_token, "signup_invitation"),
          %UserToken{sent_to: email, data: data} = token <- Repo.one(query) do
+      carried_code = if is_map(data), do: data["invite_code"], else: nil
+      invite_mode = Settings.invitation_only?()
+
       cond do
         Blacklist.blacklisted?(email) ->
           Repo.delete!(token)
           {:error, :invalid}
 
+        # Authoritative gate: invite mode is on at click time but the token
+        # carried no invite (minted while open, mode toggled on since). Distinct
+        # from a carried-but-taken invite, handled atomically in the txn below.
+        invite_mode and is_nil(carried_code) ->
+          {:error, :invite_required}
+
         true ->
           Repo.transact(fn ->
             with {:ok, user} <- register_user(%{email: email}),
                  {:ok, confirmed} <- user |> User.confirm_changeset() |> Repo.update(),
-                 :ok <- maybe_attach_provider_identity(confirmed, data) do
+                 :ok <- maybe_attach_provider_identity(confirmed, data),
+                 :ok <- redeem_if_required(invite_mode, carried_code, confirmed) do
               Repo.delete!(token)
               {:ok, confirmed}
+            else
+              # Carried invite was redeemed/revoked (or vanished) between click
+              # and now - a shared single-use code, a concurrent winner. Surface
+              # a distinct "already used" so the caller offers a fresh code.
+              {:error, :invite_taken} -> {:error, :invite_taken}
+              other -> other
             end
           end)
       end
     else
       _ -> {:error, :invalid}
+    end
+  end
+
+  # Open mode: no redemption, no gate. Invite mode: the carried code MUST resolve
+  # to a currently-redeemable invite and win the atomic redeem, else :invite_taken.
+  defp redeem_if_required(false, _code, _user), do: :ok
+
+  defp redeem_if_required(true, code, %User{} = user) do
+    case Invites.get_by_code(code) do
+      %Invite{} = invite ->
+        case Invites.redeem(invite, user) do
+          :ok -> :ok
+          {:error, :not_redeemable} -> {:error, :invite_taken}
+        end
+
+      nil ->
+        {:error, :invite_taken}
     end
   end
 
@@ -590,14 +648,18 @@ defmodule Prodigy.Portal.Accounts do
   defp maybe_attach_provider_identity(_user, data) when map_size(data) == 0, do: :ok
 
   defp maybe_attach_provider_identity(%User{} = user, %{} = data) do
-    attrs = %{
-      provider: data["provider"] || data[:provider],
-      provider_uid: data["uid"] || data[:uid]
-    }
+    provider = data["provider"] || data[:provider]
+    uid = data["uid"] || data[:uid]
 
-    case attach_identity(user, attrs) do
-      {:ok, _} -> :ok
-      {:error, _} = err -> err
+    # A token may carry only an invite_code (pure email signup) with no
+    # provider identity to attach - that's a no-op, not a bogus identity.
+    if is_nil(provider) or is_nil(uid) do
+      :ok
+    else
+      case attach_identity(user, %{provider: provider, provider_uid: uid}) do
+        {:ok, _} -> :ok
+        {:error, _} = err -> err
+      end
     end
   end
 

--- a/apps/portal/lib/portal/controllers/auth_controller.ex
+++ b/apps/portal/lib/portal/controllers/auth_controller.ex
@@ -105,6 +105,17 @@ defmodule Prodigy.Portal.AuthController do
         )
         |> redirect(to: ~p"/users/invite/required")
 
+      :invite_taken ->
+        # The invite was single-use and got redeemed first (a shared code /
+        # concurrent winner). Nothing was created; offer a fresh code + re-auth.
+        conn
+        |> Plug.Conn.delete_session(:pending_invite_code)
+        |> put_flash(
+          :error,
+          "That invitation has already been redeemed. Enter a new invitation code to continue."
+        )
+        |> redirect(to: ~p"/users/invite/required")
+
       :blocked ->
         conn
         |> put_flash(:error, "Authentication failed.")

--- a/apps/portal/lib/portal/controllers/invitation_controller.ex
+++ b/apps/portal/lib/portal/controllers/invitation_controller.ex
@@ -46,6 +46,23 @@ defmodule Prodigy.Portal.InvitationController do
         |> put_flash(:info, "Welcome! Your account is ready.")
         |> UserAuth.log_in_user(user, %{})
 
+      # Invite mode on but the token carried no still-valid invite (mode was
+      # toggled on after the link was sent).
+      {:error, :invite_required} ->
+        conn
+        |> put_flash(:error, "Sign-up is invite-only. Enter your invitation code to continue.")
+        |> redirect(to: ~p"/users/invite/required")
+
+      # Single-use invite already redeemed (shared code / concurrent winner):
+      # offer a fresh code, then re-authenticate.
+      {:error, :invite_taken} ->
+        conn
+        |> put_flash(
+          :error,
+          "That invitation has already been redeemed. Enter a new invitation code and sign in again."
+        )
+        |> redirect(to: ~p"/users/invite/required")
+
       {:error, :invalid} ->
         case Accounts.consume_provider_link_invitation(token) do
           {:ok, user} ->

--- a/apps/portal/lib/portal/invites.ex
+++ b/apps/portal/lib/portal/invites.ex
@@ -180,19 +180,28 @@ defmodule Prodigy.Portal.Invites do
   end
 
   @doc """
-  Convenience: applies `redeem_changeset/2` against the Repo. Use
-  this for iex / one-off scripts; the sign-in flow should run the
-  changeset inside its own transaction alongside user creation.
+  Atomically redeem `invite` for `redeemer` as a single compare-and-set:
+  a guarded `UPDATE ... WHERE id = ? AND redeemed_at IS NULL AND revoked_at
+  IS NULL`. Returns `:ok` only if THIS call is the one that flipped it
+  (affected exactly one row); `{:error, :not_redeemable}` if it was already
+  redeemed or revoked (a concurrent winner, a shared single-use code, or a
+  stale in-memory struct).
+
+  This is race-safe by construction - the row lock the UPDATE takes serializes
+  concurrent redemptions and the WHERE makes it succeed at most once - so it is
+  safe to run inside the user-creation transaction: a loser (`:not_redeemable`)
+  rolls the whole sign-up back. Do NOT reintroduce a read-then-write here.
   """
-  def redeem(%Invite{} = invite, %User{} = redeemer) do
-    cond do
-      not is_nil(invite.redeemed_at) -> {:error, :already_redeemed}
-      not is_nil(invite.revoked_at) -> {:error, :revoked}
-      true ->
-        invite
-        |> redeem_changeset(redeemer)
-        |> Repo.update()
-    end
+  def redeem(%Invite{id: id}, %User{id: redeemer_id}) do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    {count, _} =
+      from(i in Invite,
+        where: i.id == ^id and is_nil(i.redeemed_at) and is_nil(i.revoked_at)
+      )
+      |> Repo.update_all(set: [redeemed_at: now, redeemer_id: redeemer_id])
+
+    if count == 1, do: :ok, else: {:error, :not_redeemable}
   end
 
   @doc """

--- a/apps/portal/lib/portal/user_live/login.ex
+++ b/apps/portal/lib/portal/user_live/login.ex
@@ -199,11 +199,13 @@ defmodule Prodigy.Portal.UserLive.Login do
     form = to_form(%{"email" => email}, as: "user")
     sent_to = Phoenix.Flash.get(socket.assigns.flash, :login_sent_to)
 
-    pending_invite =
+    pending_invite_code =
       case session["pending_invite_code"] do
-        code when is_binary(code) -> Invites.get_by_code(code)
+        code when is_binary(code) -> code
         _ -> nil
       end
+
+    pending_invite = pending_invite_code && Invites.get_by_code(pending_invite_code)
 
     {:ok,
      assign(socket,
@@ -214,7 +216,8 @@ defmodule Prodigy.Portal.UserLive.Login do
        oauth_providers: Prodigy.Portal.available_oauth_providers(),
        dev_mock?: Application.get_env(:portal, :dev_routes) == true,
        invitation_only?: Settings.invitation_only?(),
-       pending_invite: pending_invite
+       pending_invite: pending_invite,
+       pending_invite_code: pending_invite_code
      )}
   end
 
@@ -250,14 +253,26 @@ defmodule Prodigy.Portal.UserLive.Login do
       %{"user" => %{"email" => email}} = params
       normalized = email |> to_string() |> String.trim()
 
-      :ok =
-        Accounts.request_access(normalized,
-          login: &url(~p"/users/login/#{&1}"),
-          confirm: &url(~p"/users/confirm/#{&1}"),
-          dismiss: &url(~p"/users/dismiss/#{&1}")
-        )
+      case Accounts.request_access(normalized,
+             [
+               login: &url(~p"/users/login/#{&1}"),
+               confirm: &url(~p"/users/confirm/#{&1}"),
+               dismiss: &url(~p"/users/dismiss/#{&1}")
+             ],
+             invite_code: socket.assigns.pending_invite_code
+           ) do
+        :ok ->
+          {:noreply, assign(socket, sent_to: display_email(normalized))}
 
-      {:noreply, assign(socket, sent_to: display_email(normalized))}
+        # New email in invite-only mode with no valid invite: no link sent.
+        # Send them to enter a code (the "First time here?" prompt is also on
+        # this page). Backstop for a form submit that bypassed that prompt.
+        {:error, :invite_required} ->
+          {:noreply,
+           socket
+           |> put_flash(:error, "Sign-up is invite-only. Enter your invitation code to continue.")
+           |> push_navigate(to: ~p"/users/invite/required")}
+      end
     end
   end
 

--- a/apps/portal/test/portal/accounts_test.exs
+++ b/apps/portal/test/portal/accounts_test.exs
@@ -649,4 +649,103 @@ defmodule Prodigy.Portal.AccountsTest do
       refute Repo.get_by(UserToken, sent_to: email)
     end
   end
+
+  describe "invitation-only gate on the email path" do
+    alias Prodigy.Core.Data.Portal.Invite
+    alias Prodigy.Portal.{Invites, Settings}
+
+    setup do
+      Prodigy.Portal.Accounts.RateLimit.reset()
+      Settings.put(nil, "invitation_only", true)
+      inviter = user_fixture() |> Ecto.Changeset.change(invite_quota: 5) |> Repo.update!()
+      {:ok, invite} = Invites.mint(inviter)
+      %{invite: invite}
+    end
+
+    defp url_fns2 do
+      [
+        login: &"https://test/users/login/#{&1}",
+        confirm: &"https://test/users/confirm/#{&1}",
+        dismiss: &"https://test/users/dismiss/#{&1}"
+      ]
+    end
+
+    test "new email, no invite -> :invite_required, nothing created" do
+      email = "gate-#{System.unique_integer([:positive])}@example.com"
+      assert {:error, :invite_required} = Accounts.request_access(email, url_fns2())
+      refute Repo.get_by(UserToken, sent_to: email, context: "signup_invitation")
+      refute Accounts.get_user_by_email(email)
+    end
+
+    test "new email + valid invite -> :ok, token carries code, invite still pending", %{
+      invite: invite
+    } do
+      email = "gate-#{System.unique_integer([:positive])}@example.com"
+      assert :ok = Accounts.request_access(email, url_fns2(), invite_code: invite.code)
+
+      token = Repo.get_by(UserToken, sent_to: email, context: "signup_invitation")
+      assert token.data["invite_code"] == invite.code
+      # NOT redeemed at send time - a lost email must not burn the code.
+      assert Repo.get(Invite, invite.id).redeemed_at == nil
+    end
+
+    test "existing user bypasses the gate (no invite needed)" do
+      user = user_fixture()
+      assert :ok = Accounts.request_access(user.email, url_fns2())
+      assert Repo.get_by(UserToken, user_id: user.id, context: "login")
+    end
+
+    test "consume with a carried invite creates the user and redeems atomically", %{
+      invite: invite
+    } do
+      email = "gate-#{System.unique_integer([:positive])}@example.com"
+
+      {encoded, token} =
+        UserToken.build_signup_invitation_token(email, %{"invite_code" => invite.code})
+
+      Repo.insert!(token)
+
+      assert {:ok, %User{id: uid}} = Accounts.consume_signup_invitation(encoded)
+      redeemed = Repo.get(Invite, invite.id)
+      assert redeemed.redeemed_at != nil
+      assert redeemed.redeemer_id == uid
+    end
+
+    test "consume when the carried invite was already redeemed -> :invite_taken, no user", %{
+      invite: invite
+    } do
+      # Someone else redeemed it first.
+      other = user_fixture()
+      assert :ok = Invites.redeem(invite, other)
+
+      email = "gate-#{System.unique_integer([:positive])}@example.com"
+
+      {encoded, token} =
+        UserToken.build_signup_invitation_token(email, %{"invite_code" => invite.code})
+
+      Repo.insert!(token)
+
+      assert {:error, :invite_taken} = Accounts.consume_signup_invitation(encoded)
+      refute Accounts.get_user_by_email(email)
+    end
+
+    test "consume with no carried invite while invite mode is on -> :invite_required" do
+      # Token minted while open; invite mode toggled on before the click.
+      email = "gate-#{System.unique_integer([:positive])}@example.com"
+      {encoded, token} = UserToken.build_signup_invitation_token(email)
+      Repo.insert!(token)
+
+      assert {:error, :invite_required} = Accounts.consume_signup_invitation(encoded)
+      refute Accounts.get_user_by_email(email)
+    end
+
+    test "Invites.redeem is single-use: second attempt loses", %{invite: invite} do
+      u1 = user_fixture()
+      u2 = user_fixture()
+      assert :ok = Invites.redeem(invite, u1)
+      assert {:error, :not_redeemable} = Invites.redeem(invite, u2)
+      # The first redeemer stands; the loser did not overwrite it.
+      assert Repo.get(Invite, invite.id).redeemer_id == u1.id
+    end
+  end
 end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -71,14 +71,26 @@ if System.get_env("RELEASE_MODE") do
   # as an alternative.
   case System.get_env("MAIL_BACKEND") do
     "smtp" ->
+      smtp_host = System.fetch_env!("MAIL_SMTP_HOST")
+
       config :portal, Prodigy.Portal.Mailer,
         adapter: Swoosh.Adapters.SMTP,
-        relay: System.fetch_env!("MAIL_SMTP_HOST"),
+        relay: smtp_host,
         port: String.to_integer(System.get_env("MAIL_SMTP_PORT", "587")),
         username: System.fetch_env!("MAIL_USERNAME"),
         password: System.fetch_env!("MAIL_PASSWORD"),
         tls: :always,
-        auth: :always
+        auth: :always,
+        # gen_smtp hands these straight to :ssl. Modern OTP aborts the
+        # STARTTLS handshake without explicit CA verification options
+        # (symptom: {:temporary_failure, _, :tls_failed} on every send).
+        tls_options: [
+          versions: [:"tlsv1.2", :"tlsv1.3"],
+          verify: :verify_peer,
+          cacerts: :public_key.cacerts_get(),
+          server_name_indication: String.to_charlist(smtp_host),
+          depth: 3
+        ]
 
       # Name shown to recipients + sender address (must be under the
       # provider's verified identity).


### PR DESCRIPTION
Email signup bypassed invite mode entirely. Adds the gate at send + consume, makes invite redemption a race-safe atomic single-use compare-and-set.