### PR TITLE
TOOLS: account-status server support + server-authoritative change-password retry

### DIFF
--- a/apps/core/lib/prodigy/core/data/service/enroller.ex
+++ b/apps/core/lib/prodigy/core/data/service/enroller.ex
@@ -29,7 +29,7 @@ defmodule Prodigy.Core.Data.Service.Enroller do
   import Ecto.Changeset
 
   alias Prodigy.Core.Data.Repo
-  alias Prodigy.Core.Data.Service.{Household, User}
+  alias Prodigy.Core.Data.Service.{Household, MemberStatus, User}
 
   # Default Personal Path entries planted at account creation. The 20-entry
   # PATH handler (`TAOPPATH.PGM`) infinite-loops when entry 1 is empty, so
@@ -141,7 +141,14 @@ defmodule Prodigy.Core.Data.Service.Enroller do
   # Mirror name/title into the household's "A" slot JSONB - the
   # denormalized copy the original RS client reads by TAC. Keeps
   # parity with the admin Users-tab edit flow.
-  defp household_profile(nil), do: %{}
+  # The A subscriber is always allocated (suffix-in-use bit) and active.
+  # The ENROLLED bit tracks date_enrolled: the CLI/no-name path leaves the
+  # A user un-enrolled (first logon enrolls), the named path enrolls now.
+  defp household_profile(nil) do
+    %{}
+    |> MemberStatus.put_suffix_in_use("A")
+    |> MemberStatus.put_indicators("A", true, false)
+  end
 
   defp household_profile({first, last}) do
     %{
@@ -150,5 +157,7 @@ defmodule Prodigy.Core.Data.Service.Enroller do
       "011A" => last,
       "011D" => "Mr."   # TODO add an argument for this.
     }
+    |> MemberStatus.put_suffix_in_use("A")
+    |> MemberStatus.put_indicators("A", true, true)
   end
 end

--- a/apps/core/lib/prodigy/core/data/service/enroller.ex
+++ b/apps/core/lib/prodigy/core/data/service/enroller.ex
@@ -97,7 +97,7 @@ defmodule Prodigy.Core.Data.Service.Enroller do
 
     household_changeset =
       %Household{id: household_id, enabled_date: today}
-      |> change(%{profile: household_profile(enroll_name)})
+      |> change(%{profile: household_profile(enroll_name, password)})
       |> put_assoc(:users, [
         %User{
           id: user_id,
@@ -144,14 +144,20 @@ defmodule Prodigy.Core.Data.Service.Enroller do
   # The A subscriber is always allocated (suffix-in-use bit) and active.
   # The ENROLLED bit tracks date_enrolled: the CLI/no-name path leaves the
   # A user un-enrolled (first logon enrolls), the named path enrolls now.
-  defp household_profile(nil) do
-    %{}
+  # 0x0113 = PRF_HOUSEHOLD_PASSWORD (#275): the creation password doubles as the
+  # household temporary password - shown on the Member Information page and used
+  # as every newly-added member's initial password. Stored plaintext (it must be
+  # displayable + reapplied); the A user's own #335 password is hashed separately
+  # and diverges once the subscriber changes it.
+  defp household_profile(nil, password) do
+    %{"0113" => password}
     |> MemberStatus.put_suffix_in_use("A")
     |> MemberStatus.put_indicators("A", true, false)
   end
 
-  defp household_profile({first, last}) do
+  defp household_profile({first, last}, password) do
     %{
+      "0113" => password,
       # 0x011B user_a_first, 0x011A user_a_last, 0x011D user_a_title
       "011B" => first,
       "011A" => last,

--- a/apps/core/lib/prodigy/core/data/service/member_status.ex
+++ b/apps/core/lib/prodigy/core/data/service/member_status.ex
@@ -1,0 +1,117 @@
+defmodule Prodigy.Core.Data.Service.MemberStatus do
+  @moduledoc """
+  Household member account-status bits, denormalized onto `household.profile`.
+
+  These back the TOOLS "Add/Suspend Member IDs" screen and the logon
+  active check.  Logged in as the subscriber (slot A) a client cannot read
+  slots B..F's own User-row fields, so per-member status rides in the
+  household-level indicator bytes, which the subscriber reads/writes in one
+  profile fetch.
+
+    * PRF_SUFFIX_IN_USE_INDICATORS (0x0115, 1 byte): bit `0x01 <<< i` means
+      suffix i (A..F) is allocated.
+    * PRF_INDICATORS_x (A=0x0120, B=0x0129, C=0x0132, D=0x013B, E=0x0144,
+      F=0x014D; 2 bytes each): byte 1 bit `0x01` = ACTIVE (0 = suspended),
+      bit `0x02` = ENROLLED (0 = not yet enrolled).  Byte 2 reserved.
+
+  Binary profile values are stored base64 in the JSONB map (a NUL "off"
+  byte can't live in JSON text), so decode/encode go through `Base`.
+  """
+
+  import Bitwise
+
+  alias Prodigy.Core.Data.Service.ProfileBackfill
+
+  @suffix_tac 0x0115
+  @indicators_tac %{
+    "A" => 0x0120,
+    "B" => 0x0129,
+    "C" => 0x0132,
+    "D" => 0x013B,
+    "E" => 0x0144,
+    "F" => 0x014D
+  }
+  @suffix_index %{"A" => 0, "B" => 1, "C" => 2, "D" => 3, "E" => 4, "F" => 5}
+
+  @active 0x01
+  @enrolled 0x02
+
+  @type suffix :: String.t()
+  @type profile :: map()
+
+  @doc "JSONB key for the suffix-in-use byte (#277 / 0x0115)."
+  @spec suffix_key() :: String.t()
+  def suffix_key, do: ProfileBackfill.tac_key(@suffix_tac)
+
+  @doc "JSONB key for a slot's PRF_INDICATORS_x byte."
+  @spec indicators_key(suffix()) :: String.t()
+  def indicators_key(suffix), do: ProfileBackfill.tac_key(Map.fetch!(@indicators_tac, suffix))
+
+  # -- suffix-in-use ---------------------------------------------------
+
+  defp first_byte(nil), do: nil
+
+  defp first_byte(stored) when is_binary(stored) do
+    case Base.decode64(stored) do
+      {:ok, <<b, _::binary>>} -> b
+      {:ok, <<>>} -> 0
+      _ -> nil
+    end
+  end
+
+  @doc "Set suffix `suffix`'s allocated bit in the profile's #277 byte."
+  @spec put_suffix_in_use(profile(), suffix()) :: profile()
+  def put_suffix_in_use(profile, suffix) do
+    cur = first_byte(Map.get(profile, suffix_key())) || 0
+    byte = cur ||| 1 <<< Map.fetch!(@suffix_index, suffix)
+    Map.put(profile, suffix_key(), Base.encode64(<<byte>>))
+  end
+
+  # -- per-member indicators -------------------------------------------
+
+  defp flags(profile, suffix), do: first_byte(Map.get(profile, indicators_key(suffix)))
+
+  @doc """
+  Whether a member's slot is active (not suspended).  A missing indicator
+  (legacy household created before this model) is treated as active so
+  existing logons are never blocked.
+  """
+  @spec active?(profile(), suffix()) :: boolean()
+  def active?(profile, suffix) do
+    case flags(profile, suffix) do
+      nil -> true
+      b -> (b &&& @active) != 0
+    end
+  end
+
+  @doc "Whether a member's slot is enrolled.  Missing indicator => not enrolled."
+  @spec enrolled?(profile(), suffix()) :: boolean()
+  def enrolled?(profile, suffix) do
+    case flags(profile, suffix) do
+      nil -> false
+      b -> (b &&& @enrolled) != 0
+    end
+  end
+
+  defp put_flags(profile, suffix, byte) do
+    Map.put(profile, indicators_key(suffix), Base.encode64(<<byte, 0x00>>))
+  end
+
+  @doc "Write a member's active/enrolled flags outright."
+  @spec put_indicators(profile(), suffix(), boolean(), boolean()) :: profile()
+  def put_indicators(profile, suffix, active, enrolled) do
+    byte = if(active, do: @active, else: 0) ||| if(enrolled, do: @enrolled, else: 0)
+    put_flags(profile, suffix, byte)
+  end
+
+  @doc "Set a member's ENROLLED bit, preserving the active bit (default active)."
+  @spec set_enrolled(profile(), suffix()) :: profile()
+  def set_enrolled(profile, suffix) do
+    cur = flags(profile, suffix) || @active
+    put_flags(profile, suffix, cur ||| @enrolled)
+  end
+
+  @doc "Suffix letter for a household user id (last character, upcased)."
+  @spec suffix_of(String.t()) :: suffix()
+  def suffix_of(user_id) when is_binary(user_id), do: String.upcase(String.last(user_id))
+end

--- a/apps/core/lib/prodigy/core/data/service/profile_schema.ex
+++ b/apps/core/lib/prodigy/core/data/service/profile_schema.ex
@@ -587,7 +587,13 @@ defmodule Prodigy.Core.Data.Service.ProfileSchema do
         label: "Password Change Try Count",
         entity: :user,
         type: :binary,
-        length: 1
+        length: 1,
+        # Server-authoritative counter: the client may RETRIEVE it (to show
+        # remaining tries) but must never WRITE it. update: [] means no
+        # requester scope authorizes a client write, so any profile-write
+        # packet including 0x0154 is rejected wholesale. Server-side
+        # increments/resets go through User.changeset and bypass this check.
+        security: %{retrieve: [:user], update: []}
       }),
     0x0155 =>
       Map.merge(@default_entry, %{

--- a/apps/core/lib/prodigy/core/data/service/user.ex
+++ b/apps/core/lib/prodigy/core/data/service/user.ex
@@ -45,6 +45,12 @@ defmodule Prodigy.Core.Data.Service.User do
     field(:profile, :map, default: %{})
   end
 
+  # PRF_COUNT_PASSWORD_CHANGE_TRYS (#340 / 0x0154): the per-user,
+  # server-authoritative failed-old-password counter for the service
+  # change-password flow. Stored as a 1-char ASCII decimal string in the
+  # JSONB profile under key "0154" ("0".."3").
+  @try_count_key "0154"
+
   def changeset(user, params \\ %{}) do
     # Castable fields are housekeeping (password, date_enrolled,
     # concurrency_limit) plus the JSONB `:profile` map. Everything
@@ -52,8 +58,34 @@ defmodule Prodigy.Core.Data.Service.User do
     # inside that map via TAC keys.
     user
     |> cast(params, [:password, :date_enrolled, :concurrency_limit, :profile])
+    |> reset_password_change_trys()
     |> put_password_hash()
   end
+
+  # Whenever a changeset introduces a :password change - a successful
+  # service change-password write OR an admin password reset - clear the
+  # failed-attempt counter (#340) so the account is no longer locked out.
+  # Reset ONLY on password change: a :profile-only change (e.g. the
+  # server-side increment) must not clear the counter. Merges into the
+  # JSONB :profile: if this changeset also changes :profile, patch that
+  # map; otherwise base it on the existing user.profile.
+  #
+  # The "zero tries" value is the ASCII digit "0" (0x30), which is JSONB-safe
+  # (it was only the NUL byte <<0>> that Postgres rejects in JSONB text). The
+  # client retrieves #340 and compares it as a numeric string, so the counter
+  # is kept as a 1-char decimal. Every reader also treats a missing/empty
+  # value as 0, so a never-set counter is semantically identical to "0".
+  defp reset_password_change_trys(%Ecto.Changeset{valid?: true, changes: %{password: _}} = changeset) do
+    base =
+      case fetch_change(changeset, :profile) do
+        {:ok, profile} when is_map(profile) -> profile
+        _ -> changeset.data.profile || %{}
+      end
+
+    put_change(changeset, :profile, Map.put(base, @try_count_key, "0"))
+  end
+
+  defp reset_password_change_trys(changeset), do: changeset
 
   # -- JSONB-backed profile accessors -----------------------------
   #

--- a/apps/core/priv/repo/migrations/20260518000000_backfill_member_status.exs
+++ b/apps/core/priv/repo/migrations/20260518000000_backfill_member_status.exs
@@ -1,0 +1,81 @@
+# Copyright 2026, Phillip Heller
+#
+# This file is part of Prodigy Reloaded.
+#
+# Prodigy Reloaded is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# Prodigy Reloaded is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+# the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License along with Prodigy Reloaded. If not,
+# see <https://www.gnu.org/licenses/>.
+
+defmodule Prodigy.Core.Data.Repo.Migrations.BackfillMemberStatus do
+  use Ecto.Migration
+  import Ecto.Query
+
+  alias Prodigy.Core.Data.Repo
+  alias Prodigy.Core.Data.Service.{Household, MemberStatus, User}
+
+  @moduledoc """
+  Backfill the household member account-status bytes the TOOLS
+  Add/Suspend screen and the logon active check read.
+
+  For every household, from its existing member `User` rows
+  (`household.id <> suffix`, A..F):
+
+    * set PRF_SUFFIX_IN_USE_INDICATORS (#277 / 0x0115) bit for each
+      allocated suffix, and
+    * set PRF_INDICATORS_<suffix> ACTIVE = (date_deleted is nil) and
+      ENROLLED = (date_enrolled is not nil).
+
+  Pre-existing accounts predate the suspend feature, so nobody is
+  suspended - ACTIVE follows the delete flag, ENROLLED follows the
+  enrollment date.  Idempotent: recomputes from the same source rows.
+  Fresh installs get these bits at creation (Enroller), so this is a
+  no-op there.
+  """
+
+  def up do
+    flush()
+
+    Repo.transaction(fn ->
+      Enum.each(Repo.all(Household), &backfill_household/1)
+    end)
+  end
+
+  def down do
+    # Additive status keys; leaving them in place is harmless and the
+    # app tolerates their absence anyway. No reversal.
+    :ok
+  end
+
+  defp backfill_household(%Household{} = household) do
+    profile = household.profile || %{}
+
+    # LIKE "<id>_" matches exactly the 7-char member ids for this household.
+    members = Repo.all(from(u in User, where: like(u.id, ^(household.id <> "_"))))
+
+    new_profile =
+      Enum.reduce(members, profile, fn %User{} = u, acc ->
+        suffix = MemberStatus.suffix_of(u.id)
+
+        if suffix in ~w(A B C D E F) do
+          acc
+          |> MemberStatus.put_suffix_in_use(suffix)
+          |> MemberStatus.put_indicators(suffix, is_nil(u.date_deleted), not is_nil(u.date_enrolled))
+        else
+          acc
+        end
+      end)
+
+    if new_profile != profile do
+      household
+      |> Ecto.Changeset.change(profile: new_profile)
+      |> Repo.update!()
+    end
+  end
+end

--- a/apps/core/priv/repo/migrations/20260518010000_backfill_household_password.exs
+++ b/apps/core/priv/repo/migrations/20260518010000_backfill_household_password.exs
@@ -1,0 +1,87 @@
+# Copyright 2026, Phillip Heller
+#
+# This file is part of Prodigy Reloaded.
+#
+# Prodigy Reloaded is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# Prodigy Reloaded is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+# the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License along with Prodigy Reloaded. If not,
+# see <https://www.gnu.org/licenses/>.
+
+defmodule Prodigy.Core.Data.Repo.Migrations.BackfillHouseholdPassword do
+  use Ecto.Migration
+
+  alias Prodigy.Core.Data.Repo
+  alias Prodigy.Core.Data.Service.Household
+
+  @moduledoc """
+  Seed the household temporary password (PRF_HOUSEHOLD_PASSWORD, #275 / 0x0113)
+  for households created before it was stored.
+
+  The TOOLS Member Information screen shows this plaintext password, and the
+  Add/Suspend flow uses it as every newly-added member's initial (enrollment)
+  password. Fresh accounts get it at creation (Enroller). Households created
+  earlier only ever had the "A" user's own password hashed onto the User row -
+  the plaintext was discarded and cannot be recovered - so this mints a FRESH
+  password and stores it in `profile["0113"]`.
+
+  Scope, deliberately minimal:
+
+    * Only households MISSING `"0113"` are touched (idempotent - re-running
+      skips any that already have it).
+    * The "A" user's login password (0x014F on the User row) is left UNTOUCHED.
+      `"0113"` is the forward-looking shared enrollment password for
+      newly-added members, independent of the A user's own credential.
+
+  The password matches what new-account creation generates - a random 6-char
+  string over the A-Z / 2-9 alphabet with the visually-ambiguous I, O, 0, 1
+  removed (see `Prodigy.Portal.SignupIds.generate_password/0`; the alphabet is
+  replicated here to keep this core migration free of a portal dependency).
+  """
+
+  # A-Z and 2-9 minus I, O, 0, 1.
+  @alphabet ~c"ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
+  @length 6
+  @key "0113"
+
+  def up do
+    flush()
+
+    Repo.transaction(fn ->
+      Enum.each(Repo.all(Household), &backfill_household/1)
+    end)
+  end
+
+  def down do
+    # The seeded values are live credentials shown to subscribers and accepted
+    # at enrollment; removing them would break the TOOLS flow. No reversal.
+    :ok
+  end
+
+  defp backfill_household(%Household{} = household) do
+    profile = household.profile || %{}
+
+    if blank?(Map.get(profile, @key)) do
+      new_profile = Map.put(profile, @key, generate_password())
+
+      household
+      |> Ecto.Changeset.change(profile: new_profile)
+      |> Repo.update!()
+    end
+  end
+
+  # Only a genuinely absent/empty value is seeded; any existing password stands.
+  defp blank?(nil), do: true
+  defp blank?(""), do: true
+  defp blank?(_), do: false
+
+  defp generate_password do
+    len = length(@alphabet)
+    for _ <- 1..@length, into: "", do: <<Enum.at(@alphabet, :rand.uniform(len) - 1)>>
+  end
+end

--- a/apps/core/test/prodigy/core/data/service/member_status_test.exs
+++ b/apps/core/test/prodigy/core/data/service/member_status_test.exs
@@ -1,0 +1,57 @@
+# Copyright 2026, Phillip Heller
+#
+# This file is part of Prodigy Reloaded.
+#
+# Prodigy Reloaded is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# Prodigy Reloaded is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+# the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License along with Prodigy Reloaded. If not,
+# see <https://www.gnu.org/licenses/>.
+
+defmodule Prodigy.Core.Data.Service.MemberStatusTest do
+  use ExUnit.Case, async: true
+
+  alias Prodigy.Core.Data.Service.MemberStatus
+
+  test "suffix-in-use bits accumulate and round-trip through base64" do
+    p = %{} |> MemberStatus.put_suffix_in_use("A") |> MemberStatus.put_suffix_in_use("C")
+
+    # A=0x01, C=0x04 -> 0x05
+    assert Base.decode64!(p[MemberStatus.suffix_key()]) == <<0x05>>
+  end
+
+  test "put_indicators encodes active/enrolled in byte 1, NUL byte 2" do
+    p = MemberStatus.put_indicators(%{}, "B", true, false)
+    assert Base.decode64!(p[MemberStatus.indicators_key("B")]) == <<0x01, 0x00>>
+    assert MemberStatus.active?(p, "B")
+    refute MemberStatus.enrolled?(p, "B")
+
+    p2 = MemberStatus.put_indicators(%{}, "B", false, true)
+    assert Base.decode64!(p2[MemberStatus.indicators_key("B")]) == <<0x02, 0x00>>
+    refute MemberStatus.active?(p2, "B")
+    assert MemberStatus.enrolled?(p2, "B")
+  end
+
+  test "set_enrolled preserves the active bit" do
+    p = MemberStatus.put_indicators(%{}, "D", true, false)
+    p = MemberStatus.set_enrolled(p, "D")
+    assert Base.decode64!(p[MemberStatus.indicators_key("D")]) == <<0x03, 0x00>>
+    assert MemberStatus.active?(p, "D")
+    assert MemberStatus.enrolled?(p, "D")
+  end
+
+  test "missing indicator reads as active but not enrolled (legacy)" do
+    assert MemberStatus.active?(%{}, "A")
+    refute MemberStatus.enrolled?(%{}, "A")
+  end
+
+  test "suffix_of takes the last id character, upcased" do
+    assert MemberStatus.suffix_of("ABCD12A") == "A"
+    assert MemberStatus.suffix_of("abcd12f") == "F"
+  end
+end

--- a/apps/portal/lib/portal/admin/users.ex
+++ b/apps/portal/lib/portal/admin/users.ex
@@ -153,6 +153,51 @@ defmodule Prodigy.Portal.Admin.Users do
     for _ <- 1..8, into: "", do: <<Enum.at(alphabet, :rand.uniform(len) - 1)>>
   end
 
+  # PRF_COUNT_PASSWORD_CHANGE_TRYS (#340 / 0x0154): the failed-old-password
+  # counter for the service change-password flow, stored as a 1-char ASCII
+  # decimal string ("0".."3") in the JSONB profile under "0154". The server
+  # locks out change-password at 3 (@max_password_change_trys in
+  # Prodigy.Server.Service.Profile).
+  @try_count_key "0154"
+  @max_password_change_trys 3
+
+  @doc """
+  `true` when the user has hit the failed-attempt cap (#340 >= 3) and can no
+  longer change their own password over TCS until an admin (or a successful
+  password reset) clears the counter.
+  """
+  def password_change_inhibited?(%User{profile: profile}) do
+    count =
+      case profile && Map.get(profile, @try_count_key) do
+        <<d>> when d in ?0..?9 -> d - ?0
+        _ -> 0
+      end
+
+    count >= @max_password_change_trys
+  end
+
+  @doc """
+  Admin-assisted unlock: reset the change-password try counter (#340) to 0 so
+  the user can retry password changes without a forced reset. Writes the
+  profile directly (a :profile-only change), so it does NOT touch the
+  reception password. Returns `{:ok, %User{}}` or `{:error, changeset}`.
+  """
+  def clear_password_change_trys(%User{} = user) do
+    # The ASCII digit "0" is the "zero tries" value (JSONB-safe, unlike a
+    # literal <<0>> NUL byte); every reader also treats missing/empty as 0.
+    new_profile = Map.put(user.profile || %{}, @try_count_key, "0")
+
+    result =
+      user
+      |> User.changeset(%{profile: new_profile})
+      |> Repo.update()
+
+    with {:ok, updated} <- result do
+      SessionManager.broadcast_profile_updated(updated.id)
+      {:ok, updated}
+    end
+  end
+
   @doc """
   Soft-delete a service user by stamping `date_deleted` with today. If the
   user is currently online, their session is force-disconnected first so

--- a/apps/portal/lib/portal/admin_live/users/edit_modal.ex
+++ b/apps/portal/lib/portal/admin_live/users/edit_modal.ex
@@ -54,7 +54,8 @@ defmodule Prodigy.Portal.AdminLive.Users.EditModal do
         assign(socket,
           form: to_form(Admin.edit_changeset(user), as: :user),
           tab: default_tab(),
-          policy: PolicyAdmin.get(user.id)
+          policy: PolicyAdmin.get(user.id),
+          password_change_inhibited: Admin.password_change_inhibited?(user)
         )
       else
         socket
@@ -91,6 +92,24 @@ defmodule Prodigy.Portal.AdminLive.Users.EditModal do
 
       {:error, reason} ->
         send(self(), {:modal_flash, :error, "Couldn't save: #{inspect(reason)}"})
+        {:noreply, socket}
+    end
+  end
+
+  # Admin-assisted unlock. The checkbox is only interactive while checked
+  # (disabled once cleared), so a click here always means "unlock": clear
+  # #340 immediately and reflect the new state. The counter can only be
+  # re-set by the server on failed retries, never from this UI.
+  def handle_event("toggle_password_inhibited", _params, socket) do
+    case Admin.clear_password_change_trys(socket.assigns.user) do
+      {:ok, user} ->
+        {:noreply,
+         socket
+         |> assign(:user, user)
+         |> assign(:password_change_inhibited, false)}
+
+      {:error, reason} ->
+        send(self(), {:modal_flash, :error, "Couldn't unlock: #{inspect(reason)}"})
         {:noreply, socket}
     end
   end
@@ -169,6 +188,35 @@ defmodule Prodigy.Portal.AdminLive.Users.EditModal do
                 </div>
                 <div :if={!group[:columns]}>
                   <.edit_field :for={spec <- group.fields} f={f} spec={spec} user={@user} />
+                </div>
+
+                <%!-- Security control lives under the Personal info tab's
+                      Status group. The "Password change inhibited" flag is
+                      derived state (#340 >= 3), not a form field; unchecking it
+                      clears the counter immediately (admin-assisted unlock)
+                      outside the form save. --%>
+                <div :if={tab.id == :info and group.title == "Status"} class="row mb-2">
+                  <label class="col-sm-4 col-form-label col-form-label-sm text-sm-end">
+                    Password change inhibited
+                    <span
+                      class="text-muted small"
+                      style="cursor: help;"
+                      title="Checked when the user has exceeded the change-password retry limit. Uncheck to unlock; a successful password reset also clears it."
+                    >(?)</span>
+                  </label>
+                  <div class="col-sm-8">
+                    <div class="form-check form-switch">
+                      <input
+                        type="checkbox"
+                        id="password-change-inhibited"
+                        class="form-check-input"
+                        checked={@password_change_inhibited}
+                        disabled={not @password_change_inhibited}
+                        phx-click="toggle_password_inhibited"
+                        phx-target={@myself}
+                      />
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>

--- a/apps/portal/lib/portal/authz.ex
+++ b/apps/portal/lib/portal/authz.ex
@@ -512,6 +512,12 @@ defmodule Prodigy.Portal.Authz do
   @doc """
   Like `grant_role/3` but takes an email instead of a user_id. Useful
   from release-eval rpc during bootstrap.
+
+  Bootstrap the first platform admin with `actor_id = nil`, e.g. under
+  compose (see DEVELOPERS.md "Promote a user to admin"):
+
+      docker exec prodigy-server-1 /prod/rel/server/bin/server rpc \\
+        'Prodigy.Portal.Authz.grant_role_by_email(nil, "user@example.com", "platform-admin")'
   """
   def grant_role_by_email(actor_id, email, role) when is_binary(email) do
     with_user_by_email(email, &grant_role(actor_id, &1, role))

--- a/apps/portal/lib/portal/signup_ids.ex
+++ b/apps/portal/lib/portal/signup_ids.ex
@@ -137,7 +137,7 @@ defmodule Prodigy.Portal.SignupIds do
   def normalize(_), do: ""
 
   @doc """
-  Generate an 8-char password using the same A-Z / 2-9 alphabet as the
+  Generate a 6-char password using the same A-Z / 2-9 alphabet as the
   admin Users tab's reset-password flow - skips visually-ambiguous
   characters (I, O, 0, 1) so the generated value reads cleanly over
   the phone and satisfies the DOS RS client's uppercase-and-digits wire
@@ -146,7 +146,7 @@ defmodule Prodigy.Portal.SignupIds do
   def generate_password do
     alphabet = ~c"ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
     len = length(alphabet)
-    for _ <- 1..8, into: "", do: <<Enum.at(alphabet, :rand.uniform(len) - 1)>>
+    for _ <- 1..6, into: "", do: <<Enum.at(alphabet, :rand.uniform(len) - 1)>>
   end
 
   # ------------------------------------------------------------------

--- a/apps/portal/test/portal/admin/users_test.exs
+++ b/apps/portal/test/portal/admin/users_test.exs
@@ -232,6 +232,55 @@ defmodule Prodigy.Portal.Admin.UsersTest do
       refute Map.has_key?(reloaded_user.profile, "0102")
     end
 
+    test "clears the password-change try counter (#340) on password reset" do
+      # An admin password reset must unlock a change-password-locked user:
+      # User.changeset resets #340 whenever :password changes.
+      {_hh, user} = subscriber!()
+
+      {:ok, locked} =
+        user
+        |> Ecto.Changeset.change(%{profile: Map.put(user.profile || %{}, "0154", "3")})
+        |> Repo.update()
+
+      assert Users.password_change_inhibited?(locked)
+
+      {:ok, reset} = Users.reset_password(locked, "FRESH99")
+      refute Users.password_change_inhibited?(reset)
+    end
+  end
+
+  describe "password_change_inhibited?/1 and clear_password_change_trys/1" do
+    test "inhibited? is true only at or above the 3-try cap" do
+      # #340 is a 1-char ASCII decimal string.
+      assert Users.password_change_inhibited?(%User{profile: %{"0154" => "3"}})
+      assert Users.password_change_inhibited?(%User{profile: %{"0154" => "9"}})
+      refute Users.password_change_inhibited?(%User{profile: %{"0154" => "2"}})
+      refute Users.password_change_inhibited?(%User{profile: %{"0154" => "0"}})
+      refute Users.password_change_inhibited?(%User{profile: %{"0154" => ""}})
+      refute Users.password_change_inhibited?(%User{profile: %{}})
+      refute Users.password_change_inhibited?(%User{profile: nil})
+    end
+
+    test "clear resets #340 without touching the reception password" do
+      {_hh, user} = subscriber!()
+      original_hash = user.password
+
+      {:ok, locked} =
+        user
+        |> Ecto.Changeset.change(%{profile: Map.put(user.profile || %{}, "0154", "3")})
+        |> Repo.update()
+
+      assert Users.password_change_inhibited?(locked)
+
+      {:ok, cleared} = Users.clear_password_change_trys(locked)
+
+      refute Users.password_change_inhibited?(cleared)
+      # Password column is untouched (this is a :profile-only write).
+      assert Repo.get(User, cleared.id).password == original_hash
+    end
+  end
+
+  describe "update/2 more" do
     test "admin edit preserves JSONB keys written by a prior TCS-only path" do
       # TCS writes go to JSONB. When an admin later edits gender,
       # the JSONB keys written by TCS (here: last_name) must survive.

--- a/apps/portal/test/portal/enroller_test.exs
+++ b/apps/portal/test/portal/enroller_test.exs
@@ -65,6 +65,20 @@ defmodule Prodigy.Core.Data.Service.EnrollerTest do
     end
   end
 
+  describe "create_subscriber/3 — household temporary password (#275 / 0113)" do
+    test "stores the creation password as the household temp password" do
+      {:ok, {household, _user}} = Enroller.create_subscriber("TEMP01", "WELCOME1")
+      assert household.profile["0113"] == "WELCOME1"
+    end
+
+    test "stores it for a named subscriber too" do
+      {:ok, {household, _user}} =
+        Enroller.create_subscriber("TEMP02", "WELCOME2", enroll_name: {"Ada", "Lovelace"})
+
+      assert household.profile["0113"] == "WELCOME2"
+    end
+  end
+
   defp tac_key(tac),
     do: tac |> Integer.to_string(16) |> String.pad_leading(4, "0") |> String.upcase()
 end

--- a/apps/portal/test/portal_test/admin_live/users_test.exs
+++ b/apps/portal/test/portal_test/admin_live/users_test.exs
@@ -158,6 +158,28 @@ defmodule Prodigy.Portal.AdminLive.UsersTest do
       view |> element("button[phx-click='close_modal']", "Cancel") |> render_click()
       refute has_element?(view, "#edit-user-form")
     end
+
+    test "password-change-inhibited checkbox renders in the Personal info tab's Status group and unchecking unlocks the user",
+         %{conn: conn, user: user} do
+      # Lock the user by pushing #340 (profile key "0154") to the cap.
+      locked =
+        user
+        |> Ecto.Changeset.change(%{profile: Map.put(user.profile || %{}, "0154", "3")})
+        |> Repo.update!()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/service/users")
+      view |> element("button[phx-click='edit'][phx-value-id=#{locked.id}]") |> render_click()
+
+      # The control lives on the default (Personal info) tab and is checked
+      # while locked.
+      assert has_element?(view, "#password-change-inhibited[checked]")
+
+      # Unchecking clears the counter (admin-assisted unlock).
+      view |> element("#password-change-inhibited") |> render_click()
+
+      refute Prodigy.Portal.Admin.Users.password_change_inhibited?(Repo.get(User, locked.id))
+      refute has_element?(view, "#password-change-inhibited[checked]")
+    end
   end
 
   describe "reset password modal" do

--- a/apps/server/lib/prodigy/server/service/enrollment.ex
+++ b/apps/server/lib/prodigy/server/service/enrollment.ex
@@ -25,7 +25,7 @@ defmodule Prodigy.Server.Service.Enrollment do
   import Ecto.Changeset
 
   alias Prodigy.Core.Data.Repo
-  alias Prodigy.Core.Data.Service.{Household, User}
+  alias Prodigy.Core.Data.Service.{Household, MemberStatus, User}
   alias Prodigy.Server.Protocol.Dia.Packet, as: DiaPacket
   alias Prodigy.Server.Protocol.Dia.Packet.Fm0
   alias Prodigy.Server.Service.{Logon, Messaging, Profile}
@@ -69,6 +69,11 @@ defmodule Prodigy.Server.Service.Enrollment do
       end
 
     user_cs = user_cs |> change(date_enrolled: Timex.today())
+
+    # Mark this member ENROLLED in the household's PRF_INDICATORS_<suffix>
+    # byte (denormalized status the TOOLS Add/Suspend screen reads), so
+    # the "not yet enrolled" asterisk clears once they enrol.
+    household_cs = mark_member_enrolled(household_cs, user)
 
     Repo.transaction(fn ->
       if household_cs, do: Repo.update!(household_cs)
@@ -116,6 +121,23 @@ defmodule Prodigy.Server.Service.Enrollment do
   # slot-A name keys, and merge their values under the user's own name
   # TACs into the user changeset's :profile change. Returns the user
   # changeset unchanged when there's nothing to mirror.
+  # Set the enrolling member's ENROLLED bit in the household's
+  # PRF_INDICATORS_<suffix> byte, preserving the active bit.  Builds a
+  # household changeset if the entries didn't already produce one.
+  defp mark_member_enrolled(household_cs, %User{household: nil}), do: household_cs
+
+  defp mark_member_enrolled(household_cs, %User{household: household} = user) do
+    suffix = MemberStatus.suffix_of(user.id)
+
+    base =
+      if household_cs,
+        do: get_field(household_cs, :profile) || %{},
+        else: household.profile || %{}
+
+    (household_cs || change(household))
+    |> change(profile: MemberStatus.set_enrolled(base, suffix))
+  end
+
   defp apply_slot_a_mirror(user_cs, nil), do: user_cs
 
   defp apply_slot_a_mirror(user_cs, household_cs) do

--- a/apps/server/lib/prodigy/server/service/enrollment.ex
+++ b/apps/server/lib/prodigy/server/service/enrollment.ex
@@ -35,13 +35,17 @@ defmodule Prodigy.Server.Service.Enrollment do
     Logger.debug("received enrollment packet: #{inspect(request, base: :hex, limit: :infinity)}")
     user_id = user.id
 
-    # The RS enrollment flow tells the subscriber that any additional
-    # household members they register here will use the *same initial
-    # password that was issued to the subscriber* - i.e., the welcome-kit
-    # credential they logged in with, NOT a new password they may choose
-    # during this enrollment (TAC 0x014F). Capture it now, before the
-    # changeset pipeline can stage the new password.
-    subscriber_initial_password = user.password
+    # Additional household members register with the household TEMPORARY
+    # password (PRF_HOUSEHOLD_PASSWORD #275 / key "0113") - the welcome-kit
+    # credential issued at account creation, NOT any new password the
+    # subscriber later chooses. Sourcing it from the household profile (rather
+    # than user.password) keeps it correct even after the subscriber changes
+    # their own password. Falls back to user.password for pre-#275 households.
+    subscriber_initial_password =
+      case user.household do
+        %{profile: %{"0113" => pw}} when is_binary(pw) -> pw
+        _ -> user.password
+      end
 
     <<0x2, type, 0x1, ^user_id::binary-size(7), _::40, _count::16-big, rest::binary>> = payload
 

--- a/apps/server/lib/prodigy/server/service/logon.ex
+++ b/apps/server/lib/prodigy/server/service/logon.ex
@@ -26,6 +26,7 @@ defmodule Prodigy.Server.Service.Logon do
   import Prodigy.Core.Util
 
   alias Prodigy.Core.Data.Repo
+  alias Prodigy.Core.Data.Service.MemberStatus
   alias Prodigy.Core.Data.Service.User
   alias Prodigy.Server.Protocol.Dia.Packet
   alias Prodigy.Server.Protocol.Dia.Packet.Fm0
@@ -234,6 +235,21 @@ defmodule Prodigy.Server.Service.Logon do
     end
   end
 
+  # A household member whose ACTIVE bit is clear in the household-level
+  # PRF_INDICATORS_<suffix> byte has been suspended (TOOLS Add/Suspend).
+  # A missing indicator (legacy household) is treated as active.
+  defp member_active(user) do
+    suffix = MemberStatus.suffix_of(user.id)
+    profile = (user.household && user.household.profile) || %{}
+
+    if MemberStatus.active?(profile, suffix) do
+      true
+    else
+      Logger.info("User #{user.id} attempted logon, but the member is suspended")
+      :suspended
+    end
+  end
+
   defp deleted(user) do
     # TODO check that date_deleted is nil or after today
     if user.date_deleted == nil do
@@ -269,6 +285,7 @@ defmodule Prodigy.Server.Service.Logon do
            {:ok, user} <- get_user(user_id, password),
            false <- deleted(user),
            true <- household_active(user),
+           true <- member_active(user),
            enrollment_status <- enrolled(user) do
 
         # create context based on enrollment status
@@ -301,6 +318,7 @@ defmodule Prodigy.Server.Service.Logon do
 #        {:enroll_subscriber, user} -> {Status.ENROLL_SUBSCRIBER, user}
 #        {:enroll_other, user} -> {Status.ENROLL_OTHER, user}
         :id_in_use -> {Status.ID_IN_USE, nil, nil}
+        :suspended -> {Status.ACCOUNT_PROBLEM, nil, nil}
         _ -> {Status.ACCOUNT_PROBLEM, nil, nil}
       end
 

--- a/apps/server/lib/prodigy/server/service/profile.ex
+++ b/apps/server/lib/prodigy/server/service/profile.ex
@@ -35,6 +35,14 @@ defmodule Prodigy.Server.Service.Profile do
   # write means "verify this old password before applying the rest".
   @verify_old_pw_tac 0x015D
 
+  # PRF_COUNT_PASSWORD_CHANGE_TRYS (#340 / 0x0154, per-user, 1 char): the
+  # server-authoritative failed-old-password counter for the service change-
+  # password flow. Incremented here on a rejected verify, reset to 0 on a
+  # successful password change, and enforced here - a modified client cannot
+  # bypass it (the old client-side counter in TOOT111E/H is gone).
+  @try_count_key "0154"
+  @max_password_change_trys 3
+
   @doc """
   Decode wire bytes back into the list of `{tac, value}` tuples the
   client sent.
@@ -225,6 +233,34 @@ defmodule Prodigy.Server.Service.Profile do
   defp cast_fields(User), do: ~w(password date_enrolled concurrency_limit profile)a
   defp cast_fields(Household), do: ~w(enabled_date disabled_date disabled_reason profile)a
 
+  # Scope enforcement: the requesting user must be permitted to UPDATE every
+  # tac in a write. The subscriber is the household's A-suffixed user id;
+  # everyone else is :user. Household / subscriber-only GEVs (the ADDRESS &
+  # MEMBER INFO / option-5 section: billing address, member add/suspend,
+  # household temp password) list only [:subscriber] in their ProfileSchema
+  # update scope, so a non-A member's packet touching one is rejected
+  # wholesale. Member self-service GEVs (own name/DOB/gender/password) list
+  # [:user], so they pass.
+  defp write_authorized?(entries, %User{} = user) do
+    scope = requester_scope(user)
+    Enum.all?(entries, fn {tac, _val} -> scope in update_scopes(tac) end)
+  end
+
+  defp requester_scope(%User{id: id}) do
+    case String.upcase(String.last(id || "") || "") do
+      "A" -> :subscriber
+      _ -> :user
+    end
+  end
+
+  defp update_scopes(tac) do
+    case ProfileSchema.get(tac) do
+      %{security: %{update: scopes}} -> scopes
+      # Unknown tac falls back to the schema default (subscriber/oms only).
+      _ -> [:subscriber, :oms]
+    end
+  end
+
   def handle(%Fm0{payload: payload} = request, %Context{user: user} = context) do
     Logger.debug("[profile] request packet: #{inspect(request, base: :hex, limit: :infinity)}")
 
@@ -240,6 +276,17 @@ defmodule Prodigy.Server.Service.Profile do
 
     entries = parse_request_values(rest)
     Logger.debug("#{inspect(entries, base: :hex, limit: :infinity)}")
+
+    # Re-read the user so server-owned mutable fields (notably the change-
+    # password try counter #340, which the client both drives and reads back)
+    # are current for BOTH reads and writes - context.user is cached at logon
+    # and would otherwise be stale. Fall back to the passed struct if the row
+    # is not persisted (in-memory test users).
+    user =
+      case user && Repo.get(User, user.id) do
+        nil -> user
+        fresh -> Repo.preload(fresh, :household)
+      end
 
     result =
       case action do
@@ -260,14 +307,32 @@ defmodule Prodigy.Server.Service.Profile do
           {verify_entries, real_entries} =
             Enum.split_with(entries, fn {tac, _} -> tac == @verify_old_pw_tac end)
 
+          # A service change-password write is one carrying the verify-old TAC.
+          password_change = verify_entries != []
+
           cond do
-            verify_entries != [] and not old_password_ok?(user, verify_entries) ->
+            password_change and password_locked_out?(user) ->
+              Logger.info("Password change for #{user.id} rejected: too many prior tries")
+              :locked_out
+
+            password_change and not old_password_ok?(user, verify_entries) ->
               Logger.info("Password change for #{user.id} rejected: old password mismatch")
+              bump_password_try_count(user)
               :verify_failed
+
+            not write_authorized?(real_entries, user) ->
+              Logger.info(
+                "Profile update for #{user.id} rejected: subscriber-only write by non-subscriber"
+              )
+
+              :scope_denied
 
             true ->
               Logger.info("Profile update received for user #{user.id}")
 
+              # A successful password change resets the try counter (#340) via
+              # User.changeset, which clears "0154" whenever :password changes -
+              # so no explicit reset entry is needed here.
               {user_changeset, household_changeset, member_patches} =
                 build_changesets(real_entries, user, user.household)
 
@@ -298,8 +363,19 @@ defmodule Prodigy.Server.Service.Profile do
       end
 
     case result do
+      :locked_out ->
+        # Too many failed old-password tries. Same coarse error as a mismatch -
+        # xxopprof conveys only success/error, so the client shows a single
+        # "Incorrect password or too many tries." message either way.
+        {:ok, context, DiaPacket.encode(Fm0.make_response(<<0x05>>, request))}
+
       :verify_failed ->
         # 1-byte non-'0' status: xxopprof reads this as an error return.
+        {:ok, context, DiaPacket.encode(Fm0.make_response(<<0x05>>, request))}
+
+      :scope_denied ->
+        # Non-subscriber attempted a subscriber-only (household) write; reject
+        # the whole packet the same way, changing nothing.
         {:ok, context, DiaPacket.encode(Fm0.make_response(<<0x05>>, request))}
 
       {:reply, values} ->
@@ -328,6 +404,31 @@ defmodule Prodigy.Server.Service.Profile do
         else: Pbkdf2.hash_pwd_salt(user.password)
 
     Pbkdf2.verify_pass(old, hash)
+  end
+
+  # -- server-authoritative change-password try counter (#340) ---------
+
+  # The counter is stored as a 1-char ASCII decimal string ("0".."3") so the
+  # reception client can retrieve #340 and compare it numerically (>= '3').
+  # nil / empty / non-digit is treated as 0.
+  defp password_try_count(%User{profile: profile}) when is_map(profile) do
+    case profile do
+      %{@try_count_key => <<d>>} when d in ?0..?9 -> d - ?0
+      _ -> 0
+    end
+  end
+
+  defp password_try_count(_), do: 0
+
+  defp password_locked_out?(user), do: password_try_count(user) >= @max_password_change_trys
+
+  # Persist an incremented try count after a rejected old-password verify.
+  # Stored as a single decimal digit; the count never exceeds 3 (a locked-out
+  # write is rejected before any increment), so one digit always suffices.
+  defp bump_password_try_count(%User{} = user) do
+    n = password_try_count(user) + 1
+    profile = Map.put(user.profile || %{}, @try_count_key, Integer.to_string(n))
+    user |> User.changeset(%{profile: profile}) |> Repo.update!()
   end
 
   # -- compat shims --------------------------------------------------

--- a/apps/server/lib/prodigy/server/service/profile.ex
+++ b/apps/server/lib/prodigy/server/service/profile.ex
@@ -31,6 +31,10 @@ defmodule Prodigy.Server.Service.Profile do
   alias Prodigy.Server.Protocol.Dia.Packet.Fm0
   alias Prodigy.Server.Context
 
+  # Transient companion TAC (never stored): its presence in a profile
+  # write means "verify this old password before applying the rest".
+  @verify_old_pw_tac 0x015D
+
   @doc """
   Decode wire bytes back into the list of `{tac, value}` tuples the
   client sent.
@@ -237,52 +241,89 @@ defmodule Prodigy.Server.Service.Profile do
     entries = parse_request_values(rest)
     Logger.debug("#{inspect(entries, base: :hex, limit: :infinity)}")
 
-    values =
+    result =
       case action do
         0x03 ->
           # Retrieve: encode each requested TAC.
-          Enum.reduce(entries, <<>>, fn {tac, _val}, buf ->
-            buf <> get_tac(tac, user, user.household)
-          end)
+          {:reply,
+           Enum.reduce(entries, <<>>, fn {tac, _val}, buf ->
+             buf <> get_tac(tac, user, user.household)
+           end)}
 
         0x04 ->
-          Logger.info("Profile update received for user #{user.id}")
+          # A change-password write carries the transient verify-old TAC
+          # (0x015D) alongside the new password (0x014F). Verify the old
+          # against the stored hash; on mismatch reject the WHOLE write
+          # (change nothing) and return a short error status. The verify
+          # TAC is never persisted. A plain write (no verify TAC) applies
+          # as before - this is how enrollment sets the initial password.
+          {verify_entries, real_entries} =
+            Enum.split_with(entries, fn {tac, _} -> tac == @verify_old_pw_tac end)
 
-          {user_changeset, household_changeset, member_patches} =
-            build_changesets(entries, user, user.household)
+          cond do
+            verify_entries != [] and not old_password_ok?(user, verify_entries) ->
+              Logger.info("Password change for #{user.id} rejected: old password mismatch")
+              :verify_failed
 
-          # New member rows get this user's password as loaded - before
-          # any password change in this update is applied - mirroring the
-          # enrollment "members share the subscriber's initial password"
-          # rule.
-          member_initial_password = user.password
+            true ->
+              Logger.info("Profile update received for user #{user.id}")
 
-          Repo.transaction(fn ->
-            if household_changeset, do: Repo.update!(household_changeset)
+              {user_changeset, household_changeset, member_patches} =
+                build_changesets(real_entries, user, user.household)
 
-            if user.household && map_size(member_patches) > 0 do
-              persist_members(member_patches, user.household, member_initial_password)
-            end
+              # New member rows get this user's password as loaded - before
+              # any password change in this update is applied - mirroring the
+              # enrollment "members share the subscriber's initial password"
+              # rule.
+              member_initial_password = user.password
 
-            Repo.update!(user_changeset |> Ecto.Changeset.change(date_enrolled: Timex.today()))
-          end)
+              Repo.transaction(fn ->
+                if household_changeset, do: Repo.update!(household_changeset)
 
-          Prodigy.Server.SessionManager.broadcast_profile_updated(user.id)
+                if user.household && map_size(member_patches) > 0 do
+                  persist_members(member_patches, user.household, member_initial_password)
+                end
 
-          payload
+                Repo.update!(user_changeset |> Ecto.Changeset.change(date_enrolled: Timex.today()))
+              end)
+
+              Prodigy.Server.SessionManager.broadcast_profile_updated(user.id)
+
+              {:reply, payload}
+          end
       end
 
-    response_payload = <<
-      0x13,
-      action,
-      which_user,
-      other_user_id::binary-size(7),
-      filler::binary-size(5),
-      0x0::16-big,
-      values::binary
-    >>
+    case result do
+      :verify_failed ->
+        # 1-byte non-'0' status: xxopprof reads this as an error return.
+        {:ok, context, DiaPacket.encode(Fm0.make_response(<<0x05>>, request))}
 
-    {:ok, context, DiaPacket.encode(Fm0.make_response(response_payload, request))}
+      {:reply, values} ->
+        response_payload = <<
+          0x13,
+          action,
+          which_user,
+          other_user_id::binary-size(7),
+          filler::binary-size(5),
+          0x0::16-big,
+          values::binary
+        >>
+
+        {:ok, context, DiaPacket.encode(Fm0.make_response(response_payload, request))}
+    end
+  end
+
+  # Verify a submitted old password against the user's stored credential,
+  # tolerating legacy rows that were stored un-hashed (mirrors Logon).
+  defp old_password_ok?(user, verify_entries) do
+    {_tac, old} = List.last(verify_entries)
+
+    hash =
+      if String.starts_with?(user.password, "$pbkdf2-sha512$"),
+        do: user.password,
+        else: Pbkdf2.hash_pwd_salt(user.password)
+
+    Pbkdf2.verify_pass(old, hash)
   end
 
   # -- compat shims --------------------------------------------------

--- a/apps/server/lib/prodigy/server/service/profile.ex
+++ b/apps/server/lib/prodigy/server/service/profile.ex
@@ -243,7 +243,14 @@ defmodule Prodigy.Server.Service.Profile do
   # [:user], so they pass.
   defp write_authorized?(entries, %User{} = user) do
     scope = requester_scope(user)
-    Enum.all?(entries, fn {tac, _val} -> scope in update_scopes(tac) end)
+
+    Enum.all?(entries, fn {tac, _val} ->
+      allowed = update_scopes(tac)
+      # A subscriber is also a :user for their own fields (e.g. their own
+      # password, 0x014F, update [:user]), so :subscriber satisfies a :user
+      # requirement in addition to :subscriber-only fields.
+      scope in allowed or (scope == :subscriber and :user in allowed)
+    end)
   end
 
   defp requester_scope(%User{id: id}) do

--- a/apps/server/lib/prodigy/server/service/profile.ex
+++ b/apps/server/lib/prodigy/server/service/profile.ex
@@ -271,11 +271,15 @@ defmodule Prodigy.Server.Service.Profile do
               {user_changeset, household_changeset, member_patches} =
                 build_changesets(real_entries, user, user.household)
 
-              # New member rows get this user's password as loaded - before
-              # any password change in this update is applied - mirroring the
-              # enrollment "members share the subscriber's initial password"
-              # rule.
-              member_initial_password = user.password
+              # New member rows get the household TEMPORARY password
+              # (PRF_HOUSEHOLD_PASSWORD #275 / key "0113"), not the subscriber's
+              # current password - which diverges once the subscriber changes
+              # it. Falls back to user.password for pre-#275 households.
+              member_initial_password =
+                case user.household do
+                  %{profile: %{"0113" => pw}} when is_binary(pw) -> pw
+                  _ -> user.password
+                end
 
               Repo.transaction(fn ->
                 if household_changeset, do: Repo.update!(household_changeset)

--- a/apps/server/test/prodigy/server/service/logon_member_status_test.exs
+++ b/apps/server/test/prodigy/server/service/logon_member_status_test.exs
@@ -1,0 +1,84 @@
+# Copyright 2026, Phillip Heller
+#
+# This file is part of Prodigy Reloaded.
+#
+# Prodigy Reloaded is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# Prodigy Reloaded is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+# the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License along with Prodigy Reloaded. If not,
+# see <https://www.gnu.org/licenses/>.
+
+defmodule Prodigy.Server.Service.LogonMemberStatus.Test do
+  @moduledoc """
+  Logon honors the TOOLS Add/Suspend member state. A household member whose
+  ACTIVE bit is clear in the household-level PRF_INDICATORS_<suffix> byte has
+  been suspended and is refused with ACCOUNT_PROBLEM; an active member logs on
+  normally. (A missing indicator - a legacy household - reads as active and is
+  covered by logon_logoff_test's SUCCESS cases.)
+  """
+  use Prodigy.Server.RepoCase
+  import Server
+  import Ecto.Changeset
+  import Mock
+
+  alias Prodigy.Core.Data.Service.{Household, MemberStatus, User}
+  alias Prodigy.Server.Protocol.Dia.Packet, as: DiaPacket
+  alias Prodigy.Server.Protocol.Dia.Packet.Fm0
+  alias Prodigy.Server.Router
+  alias Prodigy.Server.Service.Logon.Status
+
+  @moduletag :capture_log
+
+  defp epoch do
+    {:ok, result} = DateTime.from_unix(0)
+    result
+  end
+
+  setup_with_mocks([
+    {Calendar.DateTime, [], [now_utc: fn -> epoch() end]}
+  ]) do
+    {:ok, router_pid} = GenServer.start_link(Router, nil)
+    [router_pid: router_pid]
+  end
+
+  @today DateTime.to_date(DateTime.utc_now())
+
+  # Enrolled slot-A subscriber in household AAAA12, whose household profile
+  # carries the given PRF_INDICATORS_A byte.
+  defp insert_household(indicator_profile) do
+    %Household{id: "AAAA12", enabled_date: @today, profile: indicator_profile}
+    |> change
+    |> put_assoc(:users, [
+      %User{id: "AAAA12A", profile: %{"0157" => "F"}, date_enrolled: @today}
+      |> User.changeset(%{password: "foobaz"})
+    ])
+    |> Repo.insert!()
+  end
+
+  defp logon_status(pid) do
+    {:ok, response} = logon(pid, "AAAA12A", "foobaz", "06.03.10")
+    {:ok, %Fm0{payload: <<status, _rest::binary>>}} = DiaPacket.decode(response)
+    status
+  end
+
+  test "a suspended member (active bit clear) is refused at logon", context do
+    insert_household(MemberStatus.put_indicators(%{}, "A", false, true))
+
+    assert logon_status(context.router_pid) == Status.ACCOUNT_PROBLEM.value()
+
+    ensure_logoff(context.router_pid)
+  end
+
+  test "an active member (active bit set) logs on normally", context do
+    insert_household(MemberStatus.put_indicators(%{}, "A", true, true))
+
+    assert logon_status(context.router_pid) == Status.SUCCESS.value()
+
+    ensure_logoff(context.router_pid)
+  end
+end

--- a/apps/server/test/prodigy/server/service/profile_password_retry_test.exs
+++ b/apps/server/test/prodigy/server/service/profile_password_retry_test.exs
@@ -34,6 +34,7 @@ defmodule Prodigy.Server.Service.ProfilePasswordRetryTest do
 
   @verify_old_pw_tac 0x015D
   @password_tac 0x014F
+  @try_count_tac 0x0154
   @try_count_key "0154"
 
   @old_password "OLDPASS"
@@ -45,6 +46,33 @@ defmodule Prodigy.Server.Service.ProfilePasswordRetryTest do
     entries = [
       {@verify_old_pw_tac, old_pw},
       {@password_tac, new_pw}
+    ]
+
+    body =
+      Enum.reduce(entries, <<>>, fn {tac, value}, buf ->
+        buf <> <<tac::16-big, byte_size(value), value::binary>>
+      end)
+
+    payload =
+      <<0x13, 0x04, 0x1, user_id::binary-size(7), 0::40, length(entries)::16-big, body::binary>>
+
+    %Fm0{
+      src: 0x0,
+      dest: 0x2201,
+      logon_seq: 0,
+      message_id: 0,
+      function: Fm0.Function.APPL_0,
+      payload: payload
+    }
+  end
+
+  # Build a change-password 0x04 write that ALSO tries to write #340 (0x0154)
+  # directly - the hole Change B closes.
+  defp change_password_with_counter_packet(user_id, old_pw, new_pw, counter) do
+    entries = [
+      {@verify_old_pw_tac, old_pw},
+      {@password_tac, new_pw},
+      {@try_count_tac, counter}
     ]
 
     body =
@@ -206,5 +234,37 @@ defmodule Prodigy.Server.Service.ProfilePasswordRetryTest do
       |> Repo.update()
 
     assert try_count(updated) == 2
+  end
+
+  test "client write of #340 (0x0154) alongside a change-password is rejected; counter unchanged" do
+    user = fixture(1)
+    original_hash = user.password
+
+    # Correct old password, but the packet also tries to reset #340 to "0"
+    # itself. 0x0154 update scope is [] so write_authorized? rejects the
+    # whole packet - password unchanged, counter unchanged.
+    status =
+      handle_status(
+        user,
+        change_password_with_counter_packet(user.id, @old_password, @new_password, "0")
+      )
+
+    assert status == 0x05
+
+    reloaded = reload(user.id)
+    assert reloaded.password == original_hash
+    assert try_count(reloaded) == 1
+  end
+
+  test "a normal change-password (no 0x0154) succeeds and resets #340 to \"0\"" do
+    user = fixture(2)
+
+    status = handle_status(user, change_password_packet(user.id, @old_password, @new_password))
+    assert status == 0x13
+
+    reloaded = reload(user.id)
+    assert Pbkdf2.verify_pass(@new_password, reloaded.password)
+    assert reloaded.profile[@try_count_key] == "0"
+    assert try_count(reloaded) == 0
   end
 end

--- a/apps/server/test/prodigy/server/service/profile_password_retry_test.exs
+++ b/apps/server/test/prodigy/server/service/profile_password_retry_test.exs
@@ -1,0 +1,186 @@
+# Copyright 2026, Phillip Heller
+#
+# This file is part of Prodigy Reloaded.
+#
+# Prodigy Reloaded is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# Prodigy Reloaded is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+# the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License along with Prodigy Reloaded. If not,
+# see <https://www.gnu.org/licenses/>.
+
+defmodule Prodigy.Server.Service.ProfilePasswordRetryTest do
+  @moduledoc """
+  Server-authoritative change-password retry counter (#340 / 0x0154).
+
+  A service change-password write (Fm0 action 0x04) carries the transient
+  verify-old-password TAC 0x015D alongside the new password TAC 0x014F. The
+  server verifies the old password against the stored hash, enforces a 3-try
+  lockout, increments the counter on a bad verify, and resets it to 0 (via
+  User.changeset) on a successful change. These cases exercise the real
+  persistence path, so they need DB fixtures.
+  """
+  use Prodigy.Server.RepoCase
+
+  alias Prodigy.Core.Data.Service.{Household, User}
+  alias Prodigy.Server.Context
+  alias Prodigy.Server.Protocol.Dia.Packet, as: DiaPacket
+  alias Prodigy.Server.Protocol.Dia.Packet.Fm0
+  alias Prodigy.Server.Service.Profile
+
+  @verify_old_pw_tac 0x015D
+  @password_tac 0x014F
+  @try_count_key "0154"
+
+  @old_password "OLDPASS"
+  @new_password "NEWPASS"
+  @user_id "AAAA20B"
+
+  # Build a change-password 0x04 write: verify-old TAC + new-password TAC.
+  defp change_password_packet(user_id, old_pw, new_pw) do
+    entries = [
+      {@verify_old_pw_tac, old_pw},
+      {@password_tac, new_pw}
+    ]
+
+    body =
+      Enum.reduce(entries, <<>>, fn {tac, value}, buf ->
+        buf <> <<tac::16-big, byte_size(value), value::binary>>
+      end)
+
+    payload =
+      <<0x13, 0x04, 0x1, user_id::binary-size(7), 0::40, length(entries)::16-big, body::binary>>
+
+    %Fm0{
+      src: 0x0,
+      dest: 0x2201,
+      logon_seq: 0,
+      message_id: 0,
+      function: Fm0.Function.APPL_0,
+      payload: payload
+    }
+  end
+
+  defp handle_status(user, packet) do
+    {:ok, _ctx, response} = Profile.handle(packet, %Context{user: user})
+    {:ok, %Fm0{payload: <<status, _rest::binary>>}} = DiaPacket.decode(response)
+    status
+  end
+
+  # Insert a household + subscriber user (slot A) with a known password and
+  # the given #340 try count. Returns the reloaded %User{} with household
+  # preloaded (the write path reads user.household).
+  defp fixture(try_count) do
+    today = Date.utc_today()
+
+    {:ok, household} =
+      %Household{id: "AAAA20", enabled_date: today}
+      |> Household.changeset(%{})
+      |> Repo.insert()
+
+    # Insert with the password first (this resets #340 via User.changeset),
+    # then set the desired try count as a :profile-only update so it isn't
+    # cleared. The counter is a 1-char decimal string; 0 is "0" (see
+    # User.reset_password_change_trys).
+    # A household member (slot B). The password TAC 0x014F is :user-scoped,
+    # so a non-subscriber member is the actor the change-password flow
+    # authorizes (matching profile_scope_test's use of slot-B members).
+    {:ok, user} =
+      %User{id: @user_id, household_id: household.id}
+      |> User.changeset(%{password: @old_password, date_enrolled: today})
+      |> Repo.insert()
+
+    counter_value = Integer.to_string(try_count)
+
+    {:ok, user} =
+      user
+      |> User.changeset(%{profile: Map.put(user.profile || %{}, @try_count_key, counter_value)})
+      |> Repo.update()
+
+    Repo.preload(user, :household)
+  end
+
+  defp reload(user_id), do: Repo.get(User, user_id)
+
+  defp try_count(%User{profile: profile}) do
+    case profile && Map.get(profile, @try_count_key) do
+      <<d>> when d in ?0..?9 -> d - ?0
+      _ -> 0
+    end
+  end
+
+  test "(a) locked out (#340 >= 3): change-password rejected without verifying, password unchanged" do
+    user = fixture(3)
+    original_hash = user.password
+
+    # Even with the CORRECT old password, a locked-out user is refused.
+    status = handle_status(user, change_password_packet(user.id, @old_password, @new_password))
+    assert status == 0x05
+
+    reloaded = reload(user.id)
+    assert reloaded.password == original_hash
+    # Counter is untouched (no increment, no reset) - the write was refused
+    # before any verify or persistence.
+    assert try_count(reloaded) == 3
+  end
+
+  test "(b) wrong old password: #340 incremented and persisted, write rejected, password unchanged" do
+    user = fixture(1)
+    original_hash = user.password
+
+    status = handle_status(user, change_password_packet(user.id, "WRONG", @new_password))
+    assert status == 0x05
+
+    reloaded = reload(user.id)
+    assert reloaded.password == original_hash
+    assert try_count(reloaded) == 2
+  end
+
+  test "(c) correct old password: password changed AND #340 reset to 0" do
+    user = fixture(2)
+    original_hash = user.password
+
+    {:ok, _ctx, response} =
+      Profile.handle(
+        change_password_packet(user.id, @old_password, @new_password),
+        %Context{user: user}
+      )
+
+    {:ok, %Fm0{payload: <<status, _rest::binary>>}} = DiaPacket.decode(response)
+    # Success returns the original payload echoed back (status byte 0x13).
+    assert status == 0x13
+
+    reloaded = reload(user.id)
+    refute reloaded.password == original_hash
+    assert Pbkdf2.verify_pass(@new_password, reloaded.password)
+    assert try_count(reloaded) == 0
+  end
+
+  test "(d) admin path: User.changeset(user, %{password: ...}) resets #340 to 0" do
+    user = fixture(3)
+    assert try_count(user) == 3
+
+    {:ok, updated} =
+      user
+      |> User.changeset(%{password: "ADMINSET"})
+      |> Repo.update()
+
+    assert try_count(updated) == 0
+    assert Pbkdf2.verify_pass("ADMINSET", updated.password)
+  end
+
+  test "a :profile-only change does NOT reset #340" do
+    user = fixture(2)
+
+    {:ok, updated} =
+      user
+      |> User.changeset(%{profile: Map.put(user.profile, "015E", "SMITH")})
+      |> Repo.update()
+
+    assert try_count(updated) == 2
+  end
+end

--- a/apps/server/test/prodigy/server/service/profile_password_retry_test.exs
+++ b/apps/server/test/prodigy/server/service/profile_password_retry_test.exs
@@ -173,6 +173,30 @@ defmodule Prodigy.Server.Service.ProfilePasswordRetryTest do
     assert Pbkdf2.verify_pass("ADMINSET", updated.password)
   end
 
+  test "subscriber (slot A) can change their own password (subscriber scope satisfies :user)" do
+    today = Date.utc_today()
+
+    {:ok, household} =
+      %Household{id: "AAAA21", enabled_date: today}
+      |> Household.changeset(%{})
+      |> Repo.insert()
+
+    {:ok, sub} =
+      %User{id: "AAAA21A", household_id: household.id}
+      |> User.changeset(%{password: @old_password, date_enrolled: today})
+      |> Repo.insert()
+
+    sub = Repo.preload(sub, :household)
+
+    # Not scope-denied: a subscriber's own password (0x014F, update [:user]) is
+    # writable because :subscriber satisfies the :user requirement.
+    status = handle_status(sub, change_password_packet("AAAA21A", @old_password, @new_password))
+    assert status == 0x13
+
+    reloaded = reload("AAAA21A")
+    assert Pbkdf2.verify_pass(@new_password, reloaded.password)
+  end
+
   test "a :profile-only change does NOT reset #340" do
     user = fixture(2)
 

--- a/apps/server/test/prodigy/server/service/profile_reload_test.exs
+++ b/apps/server/test/prodigy/server/service/profile_reload_test.exs
@@ -1,0 +1,123 @@
+# Copyright 2026, Phillip Heller
+#
+# This file is part of Prodigy Reloaded.
+#
+# Prodigy Reloaded is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# Prodigy Reloaded is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+# the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License along with Prodigy Reloaded. If not,
+# see <https://www.gnu.org/licenses/>.
+
+defmodule Prodigy.Server.Service.ProfileReloadTest do
+  @moduledoc """
+  The profile service reloads the user from the DB at the top of handle/2, so a
+  cached context.user cannot be used to bypass - or falsely trigger - the
+  server-side change-password lockout. context.user is captured once at logon
+  and can go stale while another connection (or an admin in the portal) moves
+  the #340 (0x0154) counter. These cases hold a deliberately stale user and
+  prove the reload, not the stale copy, governs enforcement.
+  """
+  use Prodigy.Server.RepoCase
+
+  alias Prodigy.Core.Data.Service.{Household, User}
+  alias Prodigy.Server.Context
+  alias Prodigy.Server.Protocol.Dia.Packet, as: DiaPacket
+  alias Prodigy.Server.Protocol.Dia.Packet.Fm0
+  alias Prodigy.Server.Service.Profile
+
+  @verify_old_pw_tac 0x015D
+  @password_tac 0x014F
+  @try_count_key "0154"
+
+  @old_password "OLDPASS"
+  @new_password "NEWPASS"
+  @user_id "AAAA30B"
+
+  defp change_password_packet(user_id, old_pw, new_pw) do
+    entries = [{@verify_old_pw_tac, old_pw}, {@password_tac, new_pw}]
+
+    body =
+      Enum.reduce(entries, <<>>, fn {tac, value}, buf ->
+        buf <> <<tac::16-big, byte_size(value), value::binary>>
+      end)
+
+    payload =
+      <<0x13, 0x04, 0x1, user_id::binary-size(7), 0::40, length(entries)::16-big, body::binary>>
+
+    %Fm0{
+      src: 0x0,
+      dest: 0x2201,
+      logon_seq: 0,
+      message_id: 0,
+      function: Fm0.Function.APPL_0,
+      payload: payload
+    }
+  end
+
+  defp handle_status(user, packet) do
+    {:ok, _ctx, response} = Profile.handle(packet, %Context{user: user})
+    {:ok, %Fm0{payload: <<status, _rest::binary>>}} = DiaPacket.decode(response)
+    status
+  end
+
+  # Enrolled slot-B member with a known password and the given #340 count.
+  defp fixture(try_count) do
+    today = Date.utc_today()
+
+    {:ok, household} =
+      %Household{id: "AAAA30", enabled_date: today}
+      |> Household.changeset(%{})
+      |> Repo.insert()
+
+    {:ok, user} =
+      %User{id: @user_id, household_id: household.id}
+      |> User.changeset(%{password: @old_password, date_enrolled: today})
+      |> Repo.insert()
+
+    {:ok, user} =
+      user
+      |> User.changeset(%{
+        profile: Map.put(user.profile || %{}, @try_count_key, Integer.to_string(try_count))
+      })
+      |> Repo.update()
+
+    Repo.preload(user, :household)
+  end
+
+  # Move the PERSISTED counter without touching the in-memory `user` the caller
+  # still holds - simulating a context.user that went stale after logon.
+  defp set_persisted_counter(user, count) do
+    fresh = Repo.get(User, user.id)
+
+    fresh
+    |> User.changeset(%{profile: Map.put(fresh.profile, @try_count_key, Integer.to_string(count))})
+    |> Repo.update!()
+  end
+
+  test "a stale under-limit context.user cannot bypass a lockout applied in the DB" do
+    stale = fixture(0)
+    set_persisted_counter(stale, 3)
+
+    # Correct old password, but the reload sees the lock -> refused, unchanged.
+    assert handle_status(stale, change_password_packet(@user_id, @old_password, @new_password)) ==
+             0x05
+
+    assert Pbkdf2.verify_pass(@old_password, Repo.get(User, @user_id).password)
+  end
+
+  test "a stale still-locked context.user is honored once the DB counter is cleared" do
+    stale = fixture(3)
+    set_persisted_counter(stale, 0)
+
+    # The reload sees the cleared counter -> the change is allowed.
+    assert handle_status(stale, change_password_packet(@user_id, @old_password, @new_password)) ==
+             0x13
+
+    assert Pbkdf2.verify_pass(@new_password, Repo.get(User, @user_id).password)
+  end
+end

--- a/apps/server/test/prodigy/server/service/profile_scope_test.exs
+++ b/apps/server/test/prodigy/server/service/profile_scope_test.exs
@@ -1,0 +1,66 @@
+defmodule Prodigy.Server.Service.ProfileScopeTest do
+  @moduledoc """
+  Scope enforcement for profile writes (Fm0 action 0x04): a non-subscriber
+  member must not be able to update household / subscriber-only GEVs (the
+  ADDRESS & MEMBER INFO / option-5 section). These cases exercise the
+  Repo-free rejection path, so no database fixtures are needed - the write is
+  refused before any changeset is built.
+  """
+  use ExUnit.Case, async: true
+
+  alias Prodigy.Core.Data.Service.{Household, User}
+  alias Prodigy.Server.Context
+  alias Prodigy.Server.Protocol.Dia.Packet, as: DiaPacket
+  alias Prodigy.Server.Protocol.Dia.Packet.Fm0
+  alias Prodigy.Server.Service.Profile
+
+  # Build a single-entry 0x04 profile-write packet for user_id writing tac=value.
+  defp write_packet(user_id, tac, value) do
+    entry = <<tac::16-big, byte_size(value), value::binary>>
+
+    payload =
+      <<0x13, 0x04, 0x1, user_id::binary-size(7), 0::40, 1::16-big, entry::binary>>
+
+    %Fm0{
+      src: 0x0,
+      dest: 0x2201,
+      logon_seq: 0,
+      message_id: 0,
+      function: Fm0.Function.APPL_0,
+      payload: payload
+    }
+  end
+
+  defp handle_status(user, packet) do
+    {:ok, _ctx, response} = Profile.handle(packet, %Context{user: user})
+    {:ok, %Fm0{payload: <<status, _rest::binary>>}} = DiaPacket.decode(response)
+    status
+  end
+
+  # A non-A member; household present but empty so nothing is resident.
+  defp member(id), do: %User{id: id, household: %Household{id: String.slice(id, 0, 6), profile: %{}}}
+
+  test "member write to the household password (0x0113) is rejected" do
+    # 0x0113 is update: [:subscriber]; a B member is :user -> reject (status != 0x30/'0').
+    assert handle_status(member("AAAA14B"), write_packet("AAAA14B", 0x0113, "SECRET")) == 0x05
+  end
+
+  test "member write to a household billing-address GEV (0x0102) is rejected" do
+    assert handle_status(member("AAAA14C"), write_packet("AAAA14C", 0x0102, "1 MAIN ST")) == 0x05
+  end
+
+  test "member write to their OWN password (0x014F, :user scope) is not scope-denied" do
+    # 0x014F is update: [:user]; the scope check must let it through. It then
+    # proceeds to the changeset path (which needs a DB), so we only assert it
+    # is NOT the scope-denied refusal - any other outcome (including a DB error
+    # from the missing row) proves the scope gate did not block it.
+    result =
+      try do
+        handle_status(member("AAAA14D"), write_packet("AAAA14D", 0x014F, "MINE12"))
+      rescue
+        _ -> :proceeded_past_scope_gate
+      end
+
+    refute result == 0x05
+  end
+end


### PR DESCRIPTION
## Summary

Server-side support for the TOOLS self-service account-management application (pairs with the client-side TBOL/NAPLPS objects).

- **Member/account status.** Household-level `PRF_SUFFIX_IN_USE_INDICATORS` (#277) and per-slot `PRF_INDICATORS` active/enrolled bytes, denormalized on `household.profile`. The enroller seeds the A subscriber's bits, enrollment sets the enrolled bit, and **logon rejects a suspended member** (`ACCOUNT_PROBLEM`). Includes a backfill migration for pre-existing households.
- **Household temporary password (#275).** Stored at enrollment and applied on first use.
- **Server-authoritative change-password retry counter (#340).** Counts failed old-password verifies, locks the change at 3 tries, and resets to 0 on a successful change (via `User.changeset`). Stored as an ASCII digit string (JSONB can't hold a NUL). The user is **reloaded from the DB on every profile request**, so a `context.user` cached at logon can't bypass or falsely trigger the lock. `xxopprof` conveys only success/error to the client.
- **Guardrails.** Client writes to #340 are rejected (update scope `[]`); a subscriber may change their own `:user`-scoped password.
- **Portal.** "Password change inhibited" checkbox on the Service User detail page (Personal Info tab, Status group): checked at the limit, unchecking unlocks (resets the counter); a successful password reset also clears it. Hint text in an info-icon tooltip.

## Tests

50 passing (server+core 15, portal+enroller 35). New coverage:
- `logon_member_status_test.exs` -- suspended member refused at logon; active member logs on.
- `profile_reload_test.exs` -- a stale under-limit `context.user` can't bypass a DB lockout, and a stale still-locked user is honored once the DB counter is cleared (exercises the read-through reload).

## Commits (6)

1. Add TOOLS account-status server support
2. store + apply the household temporary password (#275)
3. server-authoritative change-password retry counter (#340)
4. subscriber can write their own :user fields (own password)
5. Block client writes to the change-password try counter (#340)
6. portal "Password change inhibited" checkbox with unlock