### PR TITLE
Add prodigy.portal.api_key: idempotent portal API-key provisioning

### DIFF
--- a/apps/portal/lib/mix/tasks/prodigy.portal.api_key.ex
+++ b/apps/portal/lib/mix/tasks/prodigy.portal.api_key.ex
@@ -1,0 +1,118 @@
+# Copyright 2026, Phillip Heller
+#
+# This file is part of Prodigy Reloaded.
+#
+# Prodigy Reloaded is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# Prodigy Reloaded is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+# the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License along with Prodigy Reloaded. If not,
+# see <https://www.gnu.org/licenses/>.
+
+defmodule Mix.Tasks.Prodigy.Portal.ApiKey do
+  @shortdoc "Provision a portal account + scoped API key (idempotent)"
+
+  @moduledoc """
+  Provisions a non-interactive portal account and mints an API key for it -
+  the reproducible replacement for hand-running `ApiKeys.create/2` in IEx.
+  Built for automation identities like the `content-batch` weather uploader.
+
+  Wraps `Prodigy.Portal.Provisioning.ensure_api_key/1`: get-or-create the
+  account by email, grant each scope, then mint the key (unless a live key of
+  the same name already exists).
+
+  ## Usage
+
+      mix prodigy.portal.api_key EMAIL --name NAME [--scope SCOPE]... [--force]
+
+  ## Options
+
+      --name NAME    Display name for the key; also the idempotency key -
+                     a second run with the same name will NOT re-mint.
+      --scope SCOPE  Scope to grant the account and attach to the key.
+                     Repeatable. e.g. --scope objects.upload
+      --force        Mint a new key even if one named NAME already exists
+                     (use to rotate; revoke the old one afterward).
+
+  ## Example - the content-batch uploader
+
+      mix prodigy.portal.api_key content-batch@example.com \\
+        --name content-batch --scope objects.upload
+
+  ## Production
+
+  A release has no Mix. Run the same logic against the live prod node:
+
+      bin/server rpc 'Prodigy.Portal.Provisioning.ensure_api_key(%{
+        email: "content-batch@example.com", name: "content-batch",
+        scopes: ["objects.upload"]}) |> IO.inspect()'
+
+  ## Idempotency
+
+  Account + scope grants are get-or-create / upsert. The key is minted only
+  when no live key of that name exists (the plaintext is show-once and cannot
+  be reproduced), so re-running reports "already exists" instead of piling up
+  duplicate keys.
+  """
+
+  use Mix.Task
+
+  # `compile` only, not `app.start`: like prodigy.seed, avoid booting `:server`
+  # (it binds the TCS port and collides with a running `mix phx.server`). We
+  # start just `:core` below for the Repo.
+  @requirements ["compile"]
+
+  alias Prodigy.Portal.Provisioning
+
+  @impl Mix.Task
+  def run(argv) do
+    {opts, args, _} =
+      OptionParser.parse(argv,
+        strict: [name: :string, scope: :keep, force: :boolean]
+      )
+
+    email = List.first(args) || usage("EMAIL is required")
+    name = opts[:name] || usage("--name is required")
+    scopes = for {:scope, s} <- opts, do: s
+    if scopes == [], do: usage("at least one --scope is required (e.g. --scope objects.upload)")
+
+    {:ok, _} = Application.ensure_all_started(:core)
+
+    case Provisioning.ensure_api_key(%{
+           email: email,
+           name: name,
+           scopes: scopes,
+           force: !!opts[:force]
+         }) do
+      {:minted, plaintext} ->
+        Mix.shell().info(
+          "Minted key '#{name}' for #{email} (scopes: #{Enum.join(scopes, ", ")})."
+        )
+
+        Mix.shell().info("Show-once plaintext - store it now:\n\n    #{plaintext}\n")
+
+      {:exists, _key} ->
+        Mix.shell().info(
+          "A live key named '#{name}' already exists for #{email}; not re-minting."
+        )
+
+        Mix.shell().info("To rotate: revoke it in the portal, or re-run with --force.")
+
+      {:error, {:unknown_scopes, unknown}} ->
+        Mix.raise("unknown scope(s): #{Enum.join(unknown, ", ")}")
+
+      {:error, reason} ->
+        Mix.raise("could not provision key: #{inspect(reason)}")
+    end
+  end
+
+  defp usage(msg) do
+    Mix.raise(
+      "#{msg}\n\n  mix prodigy.portal.api_key EMAIL --name NAME [--scope SCOPE]... [--force]"
+    )
+  end
+end

--- a/apps/portal/lib/portal/provisioning.ex
+++ b/apps/portal/lib/portal/provisioning.ex
@@ -1,0 +1,109 @@
+# Copyright 2026, Phillip Heller
+#
+# This file is part of Prodigy Reloaded.
+#
+# Prodigy Reloaded is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# Prodigy Reloaded is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+# the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License along with Prodigy Reloaded. If not,
+# see <https://www.gnu.org/licenses/>.
+
+defmodule Prodigy.Portal.Provisioning do
+  @moduledoc """
+  Idempotent bootstrap for non-interactive portal identities (automation /
+  service accounts) and their API keys - e.g. the `content-batch` uploader that
+  POSTs generated objects to `/api/v1/objects/upload`.
+
+  Same effect from two runtimes:
+
+    * dev / CI / an ops box with the source:
+        `mix prodigy.portal.api_key EMAIL --name NAME --scope SCOPE`
+    * prod (a release has no Mix) - against the running node:
+        `bin/server rpc 'Prodigy.Portal.Provisioning.ensure_api_key(%{
+           email: "content-batch@...", name: "content-batch",
+           scopes: ["objects.upload"]}) |> IO.inspect()'`
+
+  The scope grant is a direct `UserScope` insert rather than
+  `Authz.grant_scope/3`: this is an operator-run bootstrap primitive (DB-level
+  trust), so there is no acting user to authorize against - the classic
+  first-admin bootstrap. `ApiKeys.create/2` still enforces that the key's scopes
+  are a subset of what the owner now holds, so the grant must precede the mint.
+  """
+
+  import Ecto.Query
+
+  alias Prodigy.Core.Data.Repo
+  alias Prodigy.Core.Data.Portal.{ApiKey, UserScope}
+  alias Prodigy.Portal.{Accounts, ApiKeys, Authz}
+
+  @doc """
+  Ensures a portal account for `email`, grants it `scopes`, and mints an API key
+  named `name` scoped to `scopes`.
+
+  Idempotent where it can be: the account and scope grants are get-or-create /
+  upsert. The key itself is only minted when no live (non-revoked) key of that
+  `name` exists - because the plaintext is show-once and cannot be reproduced.
+  Pass `force: true` to mint an additional key regardless.
+
+  Returns:
+    * `{:minted, plaintext}` - a new key was created; store the plaintext now
+    * `{:exists, %ApiKey{}}` - a live key of that name already exists; untouched
+    * `{:error, term}`       - unknown scope, or a create/changeset error
+  """
+  @spec ensure_api_key(map()) ::
+          {:minted, String.t()} | {:exists, ApiKey.t()} | {:error, term()}
+  def ensure_api_key(%{email: email, name: name, scopes: scopes} = attrs)
+      when is_binary(email) and is_binary(name) and is_list(scopes) do
+    force = Map.get(attrs, :force, false)
+
+    with :ok <- validate_scopes(scopes),
+         {:ok, user} <- get_or_create_user(email) do
+      Enum.each(scopes, &grant_scope(user.id, &1))
+
+      case {existing_live_key(user.id, name), force} do
+        {%ApiKey{} = key, false} ->
+          {:exists, key}
+
+        _ ->
+          case ApiKeys.create(user.id, %{name: name, scopes: scopes}) do
+            {:ok, key} -> {:minted, key.plaintext}
+            {:error, reason} -> {:error, reason}
+          end
+      end
+    end
+  end
+
+  defp validate_scopes(scopes) do
+    case scopes -- Authz.all_scopes() do
+      [] -> :ok
+      unknown -> {:error, {:unknown_scopes, unknown}}
+    end
+  end
+
+  defp get_or_create_user(email) do
+    case Accounts.get_user_by_email(email) do
+      nil -> Accounts.register_user(%{email: email})
+      user -> {:ok, user}
+    end
+  end
+
+  defp grant_scope(user_id, scope) do
+    %{user_id: user_id, scope: scope}
+    |> UserScope.changeset()
+    |> Repo.insert(on_conflict: :nothing, conflict_target: [:user_id, :scope])
+  end
+
+  defp existing_live_key(user_id, name) do
+    Repo.one(
+      from(k in ApiKey,
+        where: k.user_id == ^user_id and k.name == ^name and is_nil(k.revoked_at),
+        limit: 1
+      )
+    )
+  end
+end


### PR DESCRIPTION
Adds a reproducible way to provision a non-interactive portal account and mint a scoped API key - the replacement for hand-running `ApiKeys.create/2` in IEx. Motivated by the `content-batch` weather uploader, which needs an `objects.upload` key to POST generated objects to `/api/v1/objects/upload`.

## What

- **`Prodigy.Portal.Provisioning.ensure_api_key/1`** (new context): get-or-create a portal account by email, grant the requested scopes, and mint a named key - but only when no live (non-revoked) key of that name already exists, since the plaintext is show-once. Returns `{:minted, plaintext}` / `{:exists, key}` / `{:error, reason}`.
- **`mix prodigy.portal.api_key EMAIL --name NAME --scope SCOPE...`** (new task): thin wrapper for dev/CI/ops.

## Runtimes

- dev / CI / ops box: `mix prodigy.portal.api_key content-batch@example.com --name content-batch --scope objects.upload`
- prod (a release has no Mix): `bin/server rpc 'Prodigy.Portal.Provisioning.ensure_api_key(%{email: "content-batch@example.com", name: "content-batch", scopes: ["objects.upload"]}) |> IO.inspect()'`

## Notes

- The scope grant is a direct `UserScope` insert rather than `Authz.grant_scope/3`: this is an operator-run bootstrap primitive (no acting user to authorize against - the first-admin bootstrap). `ApiKeys.create/2` still enforces that the key's scopes are a subset of what the owner holds, so the grant precedes the mint.
- Additive only: two new files, no changes to existing code.
- Idempotent: account + scope grants upsert; the key is minted only when absent, so re-runs report "already exists" instead of piling up duplicates.

## Testing

- Compiles clean; `mix help prodigy.portal.api_key` registers.
- The operations mirror exactly the `rpc` bootstrap proven live end-to-end while demoing the content-batch upload chain (`get_user_by_email` / `register_user`, `UserScope` grant, `ApiKeys.create`). A functional run against a live DB is the remaining check.